### PR TITLE
Terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.terraform

--- a/terraform/config.tf
+++ b/terraform/config.tf
@@ -3,6 +3,12 @@ provider "aws" {
   profile = "psf-prod"
 }
 
+provider "aws" {
+  alias   = "oregon"
+  region  = "us-west-2"
+  profile = "psf-prod"
+}
+
 
 terraform {
   backend "s3" {

--- a/terraform/config.tf
+++ b/terraform/config.tf
@@ -1,0 +1,15 @@
+provider "aws" {
+  region  = "us-east-2"
+  profile = "psf-prod"
+}
+
+
+terraform {
+  backend "s3" {
+    bucket         = "pypi-infra-terraform"
+    key            = "production"
+    region         = "us-east-2"
+    dynamodb_table = "pypi-infra-terraform-locks"
+    profile        = "psf-prod"
+  }
+}

--- a/terraform/config.tf
+++ b/terraform/config.tf
@@ -4,7 +4,7 @@ provider "aws" {
 }
 
 provider "aws" {
-  alias   = "oregon"
+  alias   = "us-west-2"
   region  = "us-west-2"
   profile = "psf-prod"
 }

--- a/terraform/dns/main.tf
+++ b/terraform/dns/main.tf
@@ -1,0 +1,13 @@
+variable "domain" {
+  type = "string"
+}
+
+
+resource "aws_route53_zone" "primary" {
+  name = "${var.domain}"
+}
+
+
+output "zone_id" {
+  value = "${aws_route53_zone.primary.zone_id}"
+}

--- a/terraform/email/main.tf
+++ b/terraform/email/main.tf
@@ -12,12 +12,28 @@ resource "aws_ses_domain_identity" "primary" {
 }
 
 
+resource "aws_ses_domain_dkim" "primary" {
+  provider = "aws.email"
+  domain = "${aws_ses_domain_identity.primary.domain}"
+}
+
+
 resource "aws_route53_record" "primary_amazonses_verification_record" {
   zone_id = "${var.zone_id}"
   name    = "_amazonses.${var.domain}"
   type    = "TXT"
   ttl     = "1800"
   records = ["${aws_ses_domain_identity.primary.verification_token}"]
+}
+
+
+resource "aws_route53_record" "primary_amazonses_dkim_record" {
+  count   = 3
+  zone_id = "${var.zone_id}"
+  name    = "${element(aws_ses_domain_dkim.primary.dkim_tokens, count.index)}._domainkey.${var.domain}"
+  type    = "CNAME"
+  ttl     = "1800"
+  records = ["${element(aws_ses_domain_dkim.primary.dkim_tokens, count.index)}.dkim.amazonses.com"]
 }
 
 

--- a/terraform/email/main.tf
+++ b/terraform/email/main.tf
@@ -1,0 +1,42 @@
+provider "aws" {}
+provider "aws" { alias = "email" }
+
+
+variable "domain" { type = "string" }
+variable "zone_id" { type = "string" }
+
+
+resource "aws_ses_domain_identity" "primary" {
+  provider = "aws.email"
+  domain   = "${var.domain}"
+}
+
+
+resource "aws_route53_record" "primary_amazonses_verification_record" {
+  zone_id = "${var.zone_id}"
+  name    = "_amazonses.${var.domain}"
+  type    = "TXT"
+  ttl     = "1800"
+  records = ["${aws_ses_domain_identity.primary.verification_token}"]
+}
+
+
+resource "aws_sns_topic" "delivery-events" {
+  provider = "aws.email"
+  name = "pypi-ses-delivery-events-topic"
+  display_name = "PyPI SES Delivery Events"
+}
+
+
+resource "aws_sqs_queue" "delivery-events" {
+  name                       = "pypi-ses-delivery-events"
+  visibility_timeout_seconds = 300
+}
+
+
+resource "aws_sns_topic_subscription" "sns-topic" {
+  provider  = "aws.email"
+  topic_arn = "${aws_sns_topic.delivery-events.arn}"
+  protocol  = "sqs"
+  endpoint  = "${aws_sqs_queue.delivery-events.arn}"
+}

--- a/terraform/email/main.tf
+++ b/terraform/email/main.tf
@@ -56,3 +56,12 @@ resource "aws_sns_topic_subscription" "sns-topic" {
   protocol  = "sqs"
   endpoint  = "${aws_sqs_queue.delivery-events.arn}"
 }
+
+
+# TODO: We can't setup the default sending policy for a SES domain yet, because this
+#       functionality doesn't exist in Terraform yet. THere is an open issue to add
+#       this (https://github.com/terraform-providers/terraform-provider-aws/issues/931)
+#       along with a PR that does the actuak work
+#       (https://github.com/terraform-providers/terraform-provider-aws/pull/2640).
+#       However, until those get added we're going to have to manually configure the
+#       SES domain to send the requisete events to our SNS topic.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -8,7 +8,7 @@ module "email" {
   source = "./email"
   providers = {
     "aws" = "aws"
-    "aws.email" = "aws.oregon"
+    "aws.email" = "aws.us-west-2"
   }
 
   domain = "pypi.org"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,16 @@
+module "dns" {
+    source = "./dns"
+    domain = "pypi.org"
+}
+
+
+module "email" {
+  source = "./email"
+  providers = {
+    "aws" = "aws"
+    "aws.email" = "aws.oregon"
+  }
+
+  domain = "pypi.org"
+  zone_id = "${module.dns.zone_id}"
+}


### PR DESCRIPTION
This sets up the start of a terraform configuration, imports the bare minimum into our route53 domain, and sets up SES for our domain. The only thing it doesn't do is actually configure SES to send notifications to our SNS topic, because (as noted in the comment) terraform doesn't yet support that.