### PR TITLE
Add tags to the resources that support it

### DIFF
--- a/terraform/dns/main.tf
+++ b/terraform/dns/main.tf
@@ -1,3 +1,4 @@
+variable "tags" { type = "map" }
 variable "primary_domain" { type = "string" }
 variable "user_content_domain" { type = "string" }
 
@@ -8,12 +9,14 @@ resource "aws_route53_delegation_set" "ns" {}
 resource "aws_route53_zone" "primary" {
   name              = "${var.primary_domain}"
   delegation_set_id = "${aws_route53_delegation_set.ns.id}"
+  tags              = "${var.tags}"
 }
 
 
 resource "aws_route53_zone" "user_content" {
-  name = "${var.user_content_domain}"
+  name              = "${var.user_content_domain}"
   delegation_set_id = "${aws_route53_delegation_set.ns.id}"
+  tags              = "${var.tags}"
 }
 
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,15 @@
+locals {
+  tags = {
+    Application = "PyPI"
+    Environment = "Production"
+  }
+}
+
+
 module "dns" {
   source = "./dns"
+
+  tags = "${local.tags}"
 
   primary_domain = "pypi.org"
   user_content_domain = "pythonhosted.org"


### PR DESCRIPTION
```
Terraform will perform the following actions:

  ~ module.dns.aws_route53_zone.primary
      tags.%:           "0" => "2"
      tags.Application: "" => "PyPI"
      tags.Environment: "" => "Production"

  ~ module.dns.aws_route53_zone.user_content
      tags.%:           "0" => "2"
      tags.Application: "" => "PyPI"
      tags.Environment: "" => "Production"


Plan: 0 to add, 2 to change, 0 to destroy.
```