### PR TITLE
Deploy a fastly service to front the legacy pythonhosted.org docs

### DIFF
--- a/terraform/docs-hosting/main.tf
+++ b/terraform/docs-hosting/main.tf
@@ -1,0 +1,60 @@
+variable "sitename" { default = "PyPI" }
+variable "zone_id" { type = "string" }
+variable "domain" { type = "string" }
+variable "conveyor_address" { type = "string" }
+
+
+locals {
+  apex_domain = "${length(split(".", var.domain)) > 2 ? false : true}"
+  records = {
+    A = ["151.101.1.63", "151.101.65.63", "151.101.129.63", "151.101.193.63"]
+    AAAA = ["2a04:4e42::319", "2a04:4e42:200::319", "2a04:4e42:400::319", "2a04:4e42:600::319"]
+    CNAME = ["dualstack.r.ssl.global.fastly.net"]
+  }
+}
+
+
+resource "aws_route53_record" "docs" {
+  zone_id = "${var.zone_id}"
+  name    = "${var.domain}"
+  type    = "${local.apex_domain ? "A" : "CNAME"}"
+  ttl     = 60
+  records = "${local.records["${local.apex_domain ? "A" : "CNAME"}"]}"
+}
+
+resource "aws_route53_record" "docs-ipv6" {
+  count = "${local.apex_domain ? 1 : 0}"
+
+  zone_id = "${var.zone_id}"
+  name    = "${var.domain}"
+  type    = "AAAA"
+  ttl     = 60
+  records = "${local.records["AAAA"]}"
+}
+
+
+resource "fastly_service_v1" "docs" {
+  name        = "${var.sitename} Docs Hosting"
+  default_ttl = 86400  # 1 day
+
+  domain { name = "${var.domain}" }
+
+  backend {
+    name              = "Conveyor"
+    shield            = "iad-va-us"
+
+    address           = "${var.conveyor_address}"
+    port              = 443
+    use_ssl           = true
+    ssl_cert_hostname = "${var.conveyor_address}"
+    ssl_sni_hostname  = "${var.conveyor_address}"
+  }
+
+  gzip { name = "Default GZIP Policy" }
+
+  vcl {
+    name    = "Main"
+    content = "${file("${path.module}/vcl/main.vcl")}"
+    main    = true
+  }
+}

--- a/terraform/docs-hosting/vcl/main.vcl
+++ b/terraform/docs-hosting/vcl/main.vcl
@@ -1,8 +1,4 @@
 sub vcl_recv {
-    declare local var.AWS-Access-Key-ID STRING;
-    declare local var.AWS-Secret-Access-Key STRING;
-    declare local var.S3-Bucket-Name STRING;
-
     # I'm not 100% sure on what this is exactly for, it was taken from the
     # Fastly documentation, however, what I *believe* it does is just ensure
     # that we don't serve a stale copy of the page from the shield node when
@@ -21,49 +17,20 @@ sub vcl_recv {
     # users for one reason or another.
     set req.url = req.url.path;
 
-    # Currently Fastly does not provide a way to access response headers when
-    # the response is a 304 response. This is because the RFC states that only
-    # a limit set of headers should be sent with a 304 response, and the rest
-    # are SHOULD NOT. Since this stripping happens *prior* to vcl_deliver being
-    # ran, that breaks our ability to log on 304 responses. Ideally at some
-    # point Fastly offers us a way to access the "real" response headers even
-    # for a 304 response, but for now, we are going to remove the headers that
-    # allow a conditional response to be made. If at some point Fastly does
-    # allow this, then we can delete this code.
-    if (!req.http.Fastly-FF
-            && req.url.path ~ "^/packages/[a-f0-9]{2}/[a-f0-9]{2}/[a-f0-9]{60}/") {
-        unset req.http.If-None-Match;
-        unset req.http.If-Modified-Since;
-    }
-
 #FASTLY recv
 
-    # We want to Force SSL for the WebUI by returning an error code directing people
-    # to instead use HTTPS.
+    # Ensure that all of our users are getting a HTTPS version of the page by
+    # redirecting them if they are not using HTTPS.
     if (!req.http.Fastly-SSL) {
-        error 803 "SSL is required";
-    }
-
-    # Requests that are for an *actual* file get disaptched to Amazon S3 instead of
-    # to our typical backends. We need to setup the request to correctly access
-    # S3 and to authorize ourselves to S3.
-    if (req.url ~ "^/packages/[a-f0-9]{2}/[a-f0-9]{2}/[a-f0-9]{60}/") {
-        # Setup our environment to better match what S3 expects/needs
-        set req.http.Host = var.S3-Bucket-Name ".s3.amazonaws.com";
-        set req.http.Date = now;
-        set req.url = regsuball(req.url, "\+", urlencode("+"));
-
-        # Compute the Authorization header that S3 requires to be able to
-        # access the files stored there.
-        set req.http.Authorization = "AWS " var.AWS-Access-Key-ID ":" digest.hmac_sha1_base64(var.AWS-Secret-Access-Key, "GET" LF LF LF req.http.Date LF "/" var.S3-Bucket-Name req.url.path);
+        error 801 "Force SSL";
     }
 
     # Do not bother to attempt to run the caching mechanisms for methods that
     # are not generally safe to cache.
     if (req.request != "HEAD" &&
-        req.request != "GET" &&
-        req.request != "FASTLYPURGE") {
-      return(pass);
+            req.request != "GET" &&
+            req.request != "FASTLYPURGE") {
+        return(pass);
     }
 
     return(lookup);
@@ -146,25 +113,6 @@ sub vcl_deliver {
     set resp.http.X-XSS-Protection = "1; mode=block";
     set resp.http.X-Content-Type-Options = "nosniff";
     set resp.http.X-Permitted-Cross-Domain-Policies = "none";
-    set resp.http.X-Robots-Header = "noindex";
-
-    # If we're not executing a shielding request, and the URL is one of our file
-    # URLs, and it's a GET request, and the response is either a 200 or a 304
-    # then we want to log an event stating that a download has taken place.
-    if (!req.http.Fastly-FF
-            && req.url.path ~ "^/packages/[a-f0-9]{2}/[a-f0-9]{2}/[a-f0-9]{60}/"
-            && req.request == "GET"
-            && http_status_matches(resp.status, "200")) {
-        log {"syslog "} req.service_id {" linehaul :: "} "2@" now "|" geoip.country_code "|" req.url.path "|" tls.client.protocol "|" tls.client.cipher "|" resp.http.x-amz-meta-project "|" resp.http.x-amz-meta-version "|" resp.http.x-amz-meta-package-type "|" req.http.user-agent;
-    }
-
-    # Unset a few headers set by Amazon that we don't really have a need/desire
-    # to send to clients.
-    unset resp.http.x-amz-replication-status;
-    unset resp.http.x-amz-meta-python-version;
-    unset resp.http.x-amz-meta-version;
-    unset resp.http.x-amz-meta-package-type;
-    unset resp.http.x-amz-meta-project;
 
     return(deliver);
 }
@@ -181,15 +129,4 @@ sub vcl_error {
             return(deliver_stale);
         }
     }
-
-    # Handle our "error" conditions which are really just ways to set synthetic
-    # responses.
-    if (obj.status == 803) {
-        set obj.status = 403;
-        set obj.response = "SSL is required";
-        set obj.http.Content-Type = "text/plain; charset=UTF-8";
-        synthetic {"SSL is required."};
-        return (deliver);
-    }
-
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -48,5 +48,14 @@ module "file-hosting" {
 }
 
 
+module "docs-hosting" {
+  source = "./docs-hosting"
+
+  zone_id          = "${module.dns.user_content_zone_id}"
+  domain           = "pythonhosted.org"
+  conveyor_address = "conveyor.cmh1.psfhosted.org"
+}
+
+
 output "nameservers" { value = ["${module.dns.nameservers}"] }
 output "ses_delivery_topic" { value = "${module.email.delivery_topic}" }


### PR DESCRIPTION
```

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create
  ~ update in-place

Terraform will perform the following actions:

  + module.docs-hosting.aws_route53_record.docs
      id:                                      <computed>
      allow_overwrite:                         "true"
      fqdn:                                    <computed>
      name:                                    "pythonhosted.org"
      records.#:                               "4"
      records.1145861945:                      "151.101.129.63"
      records.1545709132:                      "151.101.193.63"
      records.2084396284:                      "151.101.1.63"
      records.2212431859:                      "151.101.65.63"
      ttl:                                     "60"
      type:                                    "A"
      zone_id:                                 "ZGH7QIJHBXA87"

  + module.docs-hosting.aws_route53_record.docs-ipv6
      id:                                      <computed>
      allow_overwrite:                         "true"
      fqdn:                                    <computed>
      name:                                    "pythonhosted.org"
      records.#:                               "4"
      records.1966926922:                      "2a04:4e42:400::319"
      records.2383909401:                      "2a04:4e42::319"
      records.3008619981:                      "2a04:4e42:200::319"
      records.924445495:                       "2a04:4e42:600::319"
      ttl:                                     "60"
      type:                                    "AAAA"
      zone_id:                                 "ZGH7QIJHBXA87"

  + module.docs-hosting.fastly_service_v1.docs
      id:                                      <computed>
      active_version:                          <computed>
      backend.#:                               "1"
      backend.751226571.address:               "conveyor.cmh1.psfhosted.org"
      backend.751226571.auto_loadbalance:      "true"
      backend.751226571.between_bytes_timeout: "10000"
      backend.751226571.connect_timeout:       "1000"
      backend.751226571.error_threshold:       "0"
      backend.751226571.first_byte_timeout:    "15000"
      backend.751226571.healthcheck:           ""
      backend.751226571.max_conn:              "200"
      backend.751226571.max_tls_version:       ""
      backend.751226571.min_tls_version:       ""
      backend.751226571.name:                  "Conveyor"
      backend.751226571.port:                  "443"
      backend.751226571.request_condition:     ""
      backend.751226571.shield:                "iad-va-us"
      backend.751226571.ssl_ca_cert:           ""
      backend.751226571.ssl_cert_hostname:     "conveyor.cmh1.psfhosted.org"
      backend.751226571.ssl_check_cert:        "true"
      backend.751226571.ssl_ciphers:           ""
      backend.751226571.ssl_client_cert:       <sensitive>
      backend.751226571.ssl_client_key:        <sensitive>
      backend.751226571.ssl_hostname:          ""
      backend.751226571.ssl_sni_hostname:      "conveyor.cmh1.psfhosted.org"
      backend.751226571.use_ssl:               "true"
      backend.751226571.weight:                "100"
      default_host:                            <computed>
      default_ttl:                             "86400"
      domain.#:                                "1"
      domain.3751538966.comment:               ""
      domain.3751538966.name:                  "pythonhosted.org"
      gzip.#:                                  "1"
      gzip.1751413579.cache_condition:         ""
      gzip.1751413579.content_types.#:         "0"
      gzip.1751413579.extensions.#:            "0"
      gzip.1751413579.name:                    "Default GZIP Policy"
      name:                                    "PyPI Docs Hosting"
      vcl.#:                                   "1"
      vcl.183577376.content:                   "40d97826ef6123de3a48579dc2b33bb804150f91"
      vcl.183577376.main:                      "true"
      vcl.183577376.name:                      "Main"

  ~ module.file-hosting.fastly_service_v1.files
      vcl.1748719160.content:                  "sub vcl_recv {\n    declare local var.AWS-Access-Key-ID STRING;\n    declare local var.AWS-Secret-Access-Key STRING;\n    declare local var.S3-Bucket-Name STRING;\n\n    # I'm not 100% sure on what this is exactly for, it was taken from the\n    # Fastly documentation, however, what I *believe* it does is just ensure\n    # that we don't serve a stale copy of the page from the shield node when\n    # an edge node is requesting content.\n    if (req.http.Fastly-FF) {\n        set req.max_stale_while_revalidate = 0s;\n    }\n\n    # Some (Older) clients will send a hash fragment as part of the URL even\n    # though that is a local only modification. This breaks this badly for the\n    # files in S3, and in general it's just not needed.\n    set req.url = regsub(req.url, \"#.*$\", \"\");\n\n    # We do not support any kind of a query string for these files. Stripping them\n    # out here will save on cache misses for when query strings get added by end\n    # users for one reason or another.\n    set req.url = req.url.path;\n\n    # Currently Fastly does not provide a way to access response headers when\n    # the response is a 304 response. This is because the RFC states that only\n    # a limit set of headers should be sent with a 304 response, and the rest\n    # are SHOULD NOT. Since this stripping happens *prior* to vcl_deliver being\n    # ran, that breaks our ability to log on 304 responses. Ideally at some\n    # point Fastly offers us a way to access the \"real\" response headers even\n    # for a 304 response, but for now, we are going to remove the headers that\n    # allow a conditional response to be made. If at some point Fastly does\n    # allow this, then we can delete this code.\n    if (!req.http.Fastly-FF\n            && req.url.path ~ \"^/packages/[a-f0-9]{2}/[a-f0-9]{2}/[a-f0-9]{60}/\") {\n        unset req.http.If-None-Match;\n        unset req.http.If-Modified-Since;\n    }\n\n#FASTLY recv\n\n    # We want to Force SSL for the WebUI by returning an error code directing people\n    # to instead use HTTPS.\n    if (!req.http.Fastly-SSL) {\n        error 803 \"SSL is required\";\n    }\n\n    # Requests that are for an *actual* file get disaptched to Amazon S3 instead of\n    # to our typical backends. We need to setup the request to correctly access\n    # S3 and to authorize ourselves to S3.\n    if (req.url ~ \"^/packages/[a-f0-9]{2}/[a-f0-9]{2}/[a-f0-9]{60}/\") {\n        # Setup our environment to better match what S3 expects/needs\n        set req.http.Host = var.S3-Bucket-Name \".s3.amazonaws.com\";\n        set req.http.Date = now;\n        set req.url = regsuball(req.url, \"\\+\", urlencode(\"+\"));\n\n        # Compute the Authorization header that S3 requires to be able to\n        # access the files stored there.\n        set req.http.Authorization = \"AWS \" var.AWS-Access-Key-ID \":\" digest.hmac_sha1_base64(var.AWS-Secret-Access-Key, \"GET\" LF LF LF req.http.Date LF \"/\" var.S3-Bucket-Name req.url.path);\n    }\n\n    # Do not bother to attempt to run the caching mechanisms for methods that\n    # are not generally safe to cache.\n    if (req.request != \"HEAD\" &&\n        req.request != \"GET\" &&\n        req.request != \"FASTLYPURGE\") {\n      return(pass);\n    }\n\n    return(lookup);\n}\n\n\n\nsub vcl_fetch {\n    # For any 5xx status code we want to see if a stale object exists for it,\n    # if so we'll go ahead and serve it.\n    if (beresp.status >= 500 && beresp.status < 600) {\n        if (stale.exists) {\n            return(deliver_stale);\n        }\n    }\n\n#FASTLY fetch\n\n    # If we've gotten a 502 or a 503 from the backend, we'll go ahead and retry\n    # the request.\n    if ((beresp.status == 502 || beresp.status == 503) &&\n            req.restarts < 1 &&\n            (req.request == \"GET\" || req.request == \"HEAD\")) {\n        restart;\n    }\n\n    # If we've restarted, then we'll record the number of restarts.\n    if(req.restarts > 0 ) {\n        set beresp.http.Fastly-Restarts = req.restarts;\n    }\n\n    # If there is a Set-Cookie header, we'll ensure that we do not cache the\n    # response.\n    if (beresp.http.Set-Cookie) {\n        set req.http.Fastly-Cachetype = \"SETCOOKIE\";\n        return (pass);\n    }\n\n    # If we've gotten an error after the restarts we'll deliver the response\n    # with a very short cache time.\n    if (http_status_matches(beresp.status, \"500,502,503\")) {\n        set req.http.Fastly-Cachetype = \"ERROR\";\n        set beresp.ttl = 1s;\n        set beresp.grace = 5s;\n        return (deliver);\n    }\n\n    return(deliver);\n}\n\n\n\nsub vcl_deliver {\n    # If this is an error and we have a stale response available, restart so\n    # that we can pick it up and serve it.\n    if (resp.status >= 500 && resp.status < 600) {\n        if (stale.exists) {\n            restart;\n        }\n    }\n\n#FASTLY deliver\n\n    # Unset headers that we don't need/want to send on to the client because\n    # they are not generally useful.\n    unset resp.http.Via;\n\n    # Set our standard security headers, we do this in VCL rather than in\n    # the backend itself so that we always get these headers, regardless of the\n    # origin server being used.\n    set resp.http.Strict-Transport-Security = \"max-age=31536000; includeSubDomains; preload\";\n    set resp.http.X-Frame-Options = \"deny\";\n    set resp.http.X-XSS-Protection = \"1; mode=block\";\n    set resp.http.X-Content-Type-Options = \"nosniff\";\n    set resp.http.X-Permitted-Cross-Domain-Policies = \"none\";\n    set resp.http.X-Robots-Header = \"noindex\";\n\n    # If we're not executing a shielding request, and the URL is one of our file\n    # URLs, and it's a GET request, and the response is either a 200 or a 304\n    # then we want to log an event stating that a download has taken place.\n    if (!req.http.Fastly-FF\n            && req.url.path ~ \"^/packages/[a-f0-9]{2}/[a-f0-9]{2}/[a-f0-9]{60}/\"\n            && req.request == \"GET\"\n            && http_status_matches(resp.status, \"200\")) {\n        log {\"syslog \"} req.service_id {\" linehaul :: \"} \"2@\" now \"|\" geoip.country_code \"|\" req.url.path \"|\" tls.client.protocol \"|\" tls.client.cipher \"|\" resp.http.x-amz-meta-project \"|\" resp.http.x-amz-meta-version \"|\" resp.http.x-amz-meta-package-type \"|\" req.http.user-agent;\n    }\n\n    # Unset a few headers set by Amazon that we don't really have a need/desire\n    # to send to clients.\n    unset resp.http.x-amz-replication-status;\n    unset resp.http.x-amz-meta-python-version;\n    unset resp.http.x-amz-meta-version;\n    unset resp.http.x-amz-meta-package-type;\n    unset resp.http.x-amz-meta-project;\n\n    return(deliver);\n}\n\n\n\nsub vcl_error {\n#FASTLY error\n\n    # If we have a 5xx error and there is a stale object available, then we\n    # will deliver that stale object.\n    if (obj.status >= 500 && obj.status < 600) {\n        if (stale.exists) {\n            return(deliver_stale);\n        }\n    }\n\n    # Handle our \"error\" conditions which are really just ways to set synthetic\n    # responses.\n    if (obj.status == 803) {\n        set obj.status = 403;\n        set obj.response = \"SSL is required\";\n        set obj.http.Content-Type = \"text/plain; charset=UTF-8\";\n        synthetic {\"SSL is required.\"};\n        return (deliver);\n    }\n\n}\n" => ""
      vcl.1748719160.main:                     "true" => "false"
      vcl.1748719160.name:                     "Main" => ""
      vcl.983038696.content:                   "" => "ae979d7bee9b5076c52c0e4d933c40c736497454"
      vcl.983038696.main:                      "" => "true"
      vcl.983038696.name:                      "" => "Main"


Plan: 3 to add, 1 to change, 0 to destroy.

```