### PR TITLE
Use the same endpoint logic in all modules

### DIFF
--- a/terraform/docs-hosting/main.tf
+++ b/terraform/docs-hosting/main.tf
@@ -3,33 +3,12 @@ variable "zone_id" { type = "string" }
 variable "domain" { type = "string" }
 variable "conveyor_address" { type = "string" }
 
+variable "fastly_endpoints" { type = "map" }
+variable "domain_map" { type = "map" }
+
 
 locals {
   apex_domain = "${length(split(".", var.domain)) > 2 ? false : true}"
-  records = {
-    A = ["151.101.1.63", "151.101.65.63", "151.101.129.63", "151.101.193.63"]
-    AAAA = ["2a04:4e42::319", "2a04:4e42:200::319", "2a04:4e42:400::319", "2a04:4e42:600::319"]
-    CNAME = ["dualstack.r.ssl.global.fastly.net"]
-  }
-}
-
-
-resource "aws_route53_record" "docs" {
-  zone_id = "${var.zone_id}"
-  name    = "${var.domain}"
-  type    = "${local.apex_domain ? "A" : "CNAME"}"
-  ttl     = 60
-  records = "${local.records["${local.apex_domain ? "A" : "CNAME"}"]}"
-}
-
-resource "aws_route53_record" "docs-ipv6" {
-  count = "${local.apex_domain ? 1 : 0}"
-
-  zone_id = "${var.zone_id}"
-  name    = "${var.domain}"
-  type    = "AAAA"
-  ttl     = 60
-  records = "${local.records["AAAA"]}"
 }
 
 
@@ -57,4 +36,24 @@ resource "fastly_service_v1" "docs" {
     content = "${file("${path.module}/vcl/main.vcl")}"
     main    = true
   }
+}
+
+
+resource "aws_route53_record" "docs" {
+  zone_id = "${var.zone_id}"
+  name    = "${var.domain}"
+  type    = "${local.apex_domain ? "A" : "CNAME"}"
+  ttl     = 60
+  records = ["${var.fastly_endpoints["${join("_", list(var.domain_map[var.domain], local.apex_domain ? "A" : "CNAME"))}"]}"]
+}
+
+
+resource "aws_route53_record" "docs-ipv6" {
+  count = "${local.apex_domain ? 1 : 0}"
+
+  zone_id = "${var.zone_id}"
+  name    = "${var.domain}"
+  type    = "AAAA"
+  ttl     = 60
+  records = ["${var.fastly_endpoints["${join("_", list(var.domain_map[var.domain], "AAAA"))}"]}"]
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -20,7 +20,7 @@ locals {
   }
   domain_map {
     pypi.org                    = "python.map.fastly.net"
-    temp.pypi.org               = "r.ssl.fastly.net"
+    pythonhosted.org            = "r.ssl.fastly.net"
   }
 }
 
@@ -89,6 +89,9 @@ module "docs-hosting" {
   zone_id          = "${module.dns.user_content_zone_id}"
   domain           = "pythonhosted.org"
   conveyor_address = "conveyor.cmh1.psfhosted.org"
+
+  fastly_endpoints = "${local.fastly_endpoints}"
+  domain_map       = "${local.domain_map}"
 }
 
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -21,6 +21,7 @@ locals {
   domain_map {
     pypi.org                    = "python.map.fastly.net"
     pythonhosted.org            = "r.ssl.fastly.net"
+    files.pythonhosted.org      = "r.ssl.fastly.net"
   }
 }
 
@@ -80,6 +81,9 @@ module "file-hosting" {
     port    = 48175
     token   = "${var.linehaul_token}"
   }
+
+  fastly_endpoints = "${local.fastly_endpoints}"
+  domain_map       = "${local.domain_map}"
 }
 
 


### PR DESCRIPTION
Instead of duplicating (with slightly different!) logic for locating the fastly endpoint, reuse the same logic everywhere with a central mapping of domains to fastly endpoints to fastly A, AAAA, and CNAME records.