### PR TITLE
Static fallback

### DIFF
--- a/terraform/file-hosting/main.tf
+++ b/terraform/file-hosting/main.tf
@@ -2,6 +2,7 @@ variable "zone_id" { type = "string" }
 variable "domain" { type = "string" }
 variable "conveyor_address" { type = "string" }
 variable "files_bucket" { type = "string" }
+variable "mirror" { type = "string" }
 variable "linehaul" { type = "map" }
 
 variable "fastly_endpoints" { type = "map" }
@@ -37,6 +38,7 @@ resource "fastly_service_v1" "files" {
     shield            = "sea-wa-us"
 
     request_condition = "Package File"
+    healthcheck       = "S3 Health"
 
     address           = "${var.files_bucket}.s3.amazonaws.com"
     port              = 443
@@ -44,6 +46,38 @@ resource "fastly_service_v1" "files" {
     ssl_cert_hostname = "${var.files_bucket}.s3.amazonaws.com"
     ssl_sni_hostname  = "${var.files_bucket}.s3.amazonaws.com"
   }
+
+  backend {
+    name              = "Mirror"
+    auto_loadbalance  = false
+    shield            = "london_city-uk"
+
+    request_condition = "Primary Failure (Mirror-able)"
+    healthcheck       = "Mirror Health"
+
+    address           = "${var.mirror}"
+    port              = 443
+    use_ssl           = true
+    ssl_cert_hostname = "${var.mirror}"
+    ssl_sni_hostname  = "${var.mirror}"
+  }
+
+  healthcheck {
+    name   = "S3 Health"
+
+    host   = "${var.files_bucket}.s3.amazonaws.com"
+    method = "GET"
+    path   = "/_health.txt"
+  }
+
+  healthcheck {
+    name   = "Mirror Health"
+
+    host   = "${var.domain}"
+    method = "GET"
+    path   = "/last-modified"
+  }
+
 
   vcl {
     name    = "Main"
@@ -67,6 +101,13 @@ resource "fastly_service_v1" "files" {
     # our VCL, but we need to set it here so that the system is configured to
     # have it as a logger.
     response_condition = "Never"
+  }
+
+  condition {
+    name      = "Primary Failure (Mirror-able)"
+    type      = "REQUEST"
+    statement = "(!req.backend.healthy || req.restarts > 0) && req.url ~ \"^/packages/[a-f0-9]{2}/[a-f0-9]{2}/[a-f0-9]{60}/\""
+    priority  = 1
   }
 
   condition {

--- a/terraform/file-hosting/main.tf
+++ b/terraform/file-hosting/main.tf
@@ -104,17 +104,17 @@ resource "fastly_service_v1" "files" {
   }
 
   condition {
-    name      = "Primary Failure (Mirror-able)"
+    name      = "Package File"
     type      = "REQUEST"
-    statement = "(!req.backend.healthy || req.restarts > 0) && req.url ~ \"^/packages/[a-f0-9]{2}/[a-f0-9]{2}/[a-f0-9]{60}/\""
+    statement = "req.url ~ \"^/packages/[a-f0-9]{2}/[a-f0-9]{2}/[a-f0-9]{60}/\""
     priority  = 1
   }
 
   condition {
-    name      = "Package File"
+    name      = "Primary Failure (Mirror-able)"
     type      = "REQUEST"
-    statement = "req.url ~ \"^/packages/[a-f0-9]{2}/[a-f0-9]{2}/[a-f0-9]{60}/\""
-    priority  = 5
+    statement = "(!req.backend.healthy || req.restarts > 0) && req.url ~ \"^/packages/[a-f0-9]{2}/[a-f0-9]{2}/[a-f0-9]{60}/\""
+    priority  = 2
   }
 
   condition {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -75,6 +75,7 @@ module "file-hosting" {
   domain           = "files.pythonhosted.org"
   conveyor_address = "conveyor.cmh1.psfhosted.org"
   files_bucket     = "pypi-files"
+  mirror           = "mirror.dub1.pypi.io"
 
   linehaul = {
     address = "linehaul01.iad1.psf.io"

--- a/terraform/warehouse/main.tf
+++ b/terraform/warehouse/main.tf
@@ -102,7 +102,7 @@ resource "fastly_service_v1" "pypi" {
   condition {
     name      = "Primary Failure (Mirror-able)"
     type      = "REQUEST"
-    statement = "(!req.backend.healthy || req.restarts > 0) && req.url ~ \"^/simple/\""
+    statement = "(!req.backend.healthy || req.restarts > 0) && (req.url ~ \"^/simple/\" || req.url ~ \"/pypi/[^/]+(/[^/]+)?/json$\")"
     priority  = 1
   }
 

--- a/terraform/warehouse/main.tf
+++ b/terraform/warehouse/main.tf
@@ -102,7 +102,7 @@ resource "fastly_service_v1" "pypi" {
   condition {
     name      = "Primary Failure (Mirror-able)"
     type      = "REQUEST"
-    statement = "(!req.backend.healthy || req.restarts > 0) && req.url ~ \"^/(simple|packages)/\""
+    statement = "(!req.backend.healthy || req.restarts > 0) && req.url ~ \"^/simple/\""
     priority  = 1
   }
 

--- a/terraform/warehouse/main.tf
+++ b/terraform/warehouse/main.tf
@@ -102,7 +102,7 @@ resource "fastly_service_v1" "pypi" {
   condition {
     name      = "Primary Failure (Mirror-able)"
     type      = "REQUEST"
-    statement = "(!req.backend.healthy || req.restarts > 0) && (req.url ~ \"^/simple/\" || req.url ~ \"/pypi/[^/]+(/[^/]+)?/json$\")"
+    statement = "(!req.backend.healthy || req.restarts > 0) && (req.url ~ \"^/simple/\" || req.url ~ \"^/pypi/[^/]+(/[^/]+)?/json$\")"
     priority  = 1
   }
 


### PR DESCRIPTION
* Turns on health checks for the S3 bucket.
* Enables static fallback for URLs matching ``^/packages/[a-f0-9]{2}/[a-f0-9]{2}/[a-f0-9]{60}/`` if their backend (S3) is unhealthy.
* Enables static fallback for URLs matching ``^/pypi/[^/]+(/[^/]+)?/json`` if their backend (Warehouse) is unhealthy.

Between this and the other PR, they both expect that ``mirror.dub1.pypi.io`` will function with a host header of ``pypi.io`` or ``files.pythonhosted.org``.