### PR TITLE
Move Pretty 503 to later in the request/response cycle

### DIFF
--- a/terraform/docs-hosting/vcl/main.vcl
+++ b/terraform/docs-hosting/vcl/main.vcl
@@ -46,13 +46,18 @@ sub vcl_fetch {
         set beresp.cacheable = true;
     }
 
-    # For any 5xx status code we want to see if a stale object exists for it,
-    # if so we'll go ahead and serve it.
+    # Handle 5XX (or any other unwanted status code)
     if (beresp.status >= 500 && beresp.status < 600) {
+        # Deliver stale if the object is available
         if (stale.exists) {
             return(deliver_stale);
         }
+
+        if (req.restarts < 1 && (req.request == "GET" || req.request == "HEAD")) {
+            restart;
+        }
     }
+
 
 #FASTLY fetch
 
@@ -83,6 +88,20 @@ sub vcl_fetch {
         set beresp.ttl = 1s;
         set beresp.grace = 5s;
         return (deliver);
+    }
+
+    return(deliver);
+}
+
+
+
+sub vcl_hit {
+#FASTLY hit
+
+    # If the object we have isn't cacheable, then just serve it directly
+    # without going through any of the caching mechanisms.
+    if (!obj.cacheable) {
+        return(pass);
     }
 
     return(deliver);


### PR DESCRIPTION
This moves the pretty 503 logic to later in the request/response cycle. Previously we were checking if the backend was healthy or not in ``vcl_recv`` which bypasses the cache completely so even if we had non-stale cached pages for a request it wouldn't serve them. This also defeated the ``stale-if-error`` directive, which would serve stale content if the backend was down and we had it laying around.

This logic waits until the very end, until we're in ``vcl_error`` without any stale content to serve, and then it returns a pretty, synthetic 503 error page. In order to do this I had to turn our VCL into a template so terraform could inject the pretty 503 html as a synthetic response, since Fastly doesn't make it possible to add a response object to the ``vcl_error`` block.

This is taken from https://docs.fastly.com/guides/performance-tuning/serving-stale-content.

We might want to go through warehouse and validate that we're happy with all of the ``stale_if_error`` and ``stale_while_revalidate`` values. Those values will get added onto the *end* of any cache period, so for instance a ``CacheControl: max-age=600 stale-if-error=60`` will serve the page from cache for 600 seconds regardless of the health of the backend, and then for an additional 60 seconds if the backend is unhealthy.

This PR does not affect the static mirror fallback EXCEPT in that if both warehouse and the static mirror are down, then it can still fallback to serving cached values (or stale cached values).