### PR TITLE
tune connect_timeout and error_threshold for backends

### DIFF
--- a/terraform/file-hosting/main.tf
+++ b/terraform/file-hosting/main.tf
@@ -31,6 +31,9 @@ resource "fastly_service_v1" "files" {
     use_ssl           = true
     ssl_cert_hostname = "${var.conveyor_address}"
     ssl_sni_hostname  = "${var.conveyor_address}"
+
+    connect_timeout   = 3000
+    error_threshold   = 5
   }
 
   backend {
@@ -46,6 +49,9 @@ resource "fastly_service_v1" "files" {
     use_ssl           = true
     ssl_cert_hostname = "${var.files_bucket}.s3.amazonaws.com"
     ssl_sni_hostname  = "${var.files_bucket}.s3.amazonaws.com"
+
+    connect_timeout   = 3000
+    error_threshold   = 5
   }
 
   backend {
@@ -61,6 +67,9 @@ resource "fastly_service_v1" "files" {
     use_ssl           = true
     ssl_cert_hostname = "${var.mirror}"
     ssl_sni_hostname  = "${var.mirror}"
+
+    connect_timeout   = 3000
+    error_threshold   = 5
   }
 
   healthcheck {
@@ -119,7 +128,7 @@ resource "fastly_service_v1" "files" {
   s3logging {
     name           = "S3 Error Logs"
 
-    format         = "%h \"%{now}V\" %l \"%{req.request}V %{req.url}V\" %{req.proto}V %>s %{resp.http.Content-Length}V %{resp.http.age}V \"%{resp.http.x-cache}V\" \"%{resp.http.x-cache-hits}V\" \"%{req.http.content-type}V\" \"%{req.http.accept-language}V\" \"%{cstr_escape(req.http.user-agent)}V\""
+    format         = "%h \"%{now}V\" %l \"%{req.request}V %{req.url}V\" %{req.proto}V %>s %{resp.http.Content-Length}V %{resp.http.age}V \"%{resp.http.x-cache}V\" \"%{resp.http.x-cache-hits}V\" \"%{req.http.content-type}V\" \"%{req.http.accept-language}V\" \"%{cstr_escape(req.http.user-agent)}V\" %D \"%{fastly_info.state}V\""
     format_version = 2
     gzip_level     = 9
 

--- a/terraform/warehouse/main.tf
+++ b/terraform/warehouse/main.tf
@@ -45,6 +45,9 @@ resource "fastly_service_v1" "pypi" {
     use_ssl           = true
     ssl_cert_hostname = "${var.backend}"
     ssl_sni_hostname  = "${var.backend}"
+
+    connect_timeout   = 3000
+    error_threshold   = 5
   }
 
   backend {
@@ -60,6 +63,9 @@ resource "fastly_service_v1" "pypi" {
     use_ssl           = true
     ssl_cert_hostname = "${var.mirror}"
     ssl_sni_hostname  = "${var.mirror}"
+
+    connect_timeout   = 3000
+    error_threshold   = 5
   }
 
   healthcheck {
@@ -113,7 +119,7 @@ resource "fastly_service_v1" "pypi" {
   s3logging {
     name           = "S3 Error Logs"
 
-    format         = "%h \"%{now}V\" %l \"%{req.request}V %{req.url}V\" %{req.proto}V %>s %{resp.http.Content-Length}V %{resp.http.age}V \"%{resp.http.x-cache}V\" \"%{resp.http.x-cache-hits}V\" \"%{req.http.content-type}V\" \"%{req.http.accept-language}V\" \"%{cstr_escape(req.http.user-agent)}V\""
+    format         = "%h \"%{now}V\" %l \"%{req.request}V %{req.url}V\" %{req.proto}V %>s %{resp.http.Content-Length}V %{resp.http.age}V \"%{resp.http.x-cache}V\" \"%{resp.http.x-cache-hits}V\" \"%{req.http.content-type}V\" \"%{req.http.accept-language}V\" \"%{cstr_escape(req.http.user-agent)}V\" %D \"%{fastly_info.state}V\""
     format_version = 2
     gzip_level     = 9
 


### PR DESCRIPTION
This resolves some outstanding 5xx errors at edge.

1) Gives backends a bit more time to connect. `/pypi` XMLRPC requests coming from the legacy service were seeing some trouble with regularity.

2) Ups error_threshold for backends. Since we don't have Multiple backends for warehouse anymore and just a single endpoint, it's probably a bad idea to go into an error state if a single error occurs.

3) Improves S3 Error Logging to include Fastly's request status and a service time (to debug timeouts)