### PR TITLE
support multiple google-site-verification TXT records

### DIFF
--- a/terraform/dns/main.tf
+++ b/terraform/dns/main.tf
@@ -1,7 +1,7 @@
 variable "tags" { type = "map" }
 variable "primary_domain" { type = "string" }
 variable "user_content_domain" { type = "string" }
-variable "google_verification" { type = "map" }
+variable "google_verification" { type = "list" }
 
 
 resource "aws_route53_delegation_set" "ns" {}
@@ -19,7 +19,7 @@ resource "aws_route53_record" "google-verify" {
   name    = "${var.primary_domain}"
   type    = "TXT"
   ttl     = 60
-  records = ["${var.google_verification["primary"]}"]
+  records = "${var.google_verification}"
 }
 
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -34,9 +34,10 @@ module "dns" {
   primary_domain = "pypi.org"
   user_content_domain = "pythonhosted.org"
 
-  google_verification = {
-    primary = "google-site-verification=YdrllWIiutXFzqhEamHP4HgCoh88dTFzb2A6QFljooc"
-  }
+  google_verification = [
+    "google-site-verification=YdrllWIiutXFzqhEamHP4HgCoh88dTFzb2A6QFljooc",
+    "google-site-verification=ZI8zeHE6SWuJljW3f4csGetjOWo4krvjf13tdORsH4Y"
+  ]
 }
 
 


### PR DESCRIPTION
```
  ~ module.dns.aws_route53_record.google-verify
      records.#:          "1" => "2"
      records.1535138413: "google-site-verification=YdrllWIiutXFzqhEamHP4HgCoh88dTFzb2A6QFljooc" => "google-site-verification=YdrllWIiutXFzqhEamHP4HgCoh88dTFzb2A6QFljooc"
      records.831471624:  "" => "google-site-verification=ZI8zeHE6SWuJljW3f4csGetjOWo4krvjf13tdORsH4Y"


Plan: 0 to add, 1 to change, 0 to destroy.
```