### PR TITLE
setup SES/SNS for testpypi email

### DIFF
--- a/terraform/email/main.tf
+++ b/terraform/email/main.tf
@@ -5,6 +5,8 @@ provider "aws" {
 }
 
 
+variable "name" { type = "string" }
+variable "display_name" { type = "string" }
 variable "domain" { type = "string" }
 variable "zone_id" { type = "string" }
 variable "hook_url" { type = "string" }
@@ -43,8 +45,8 @@ resource "aws_route53_record" "primary_amazonses_dkim_record" {
 
 resource "aws_sns_topic" "delivery-events" {
   provider = "aws.email"
-  name = "pypi-ses-delivery-events-topic"
-  display_name = "PyPI SES Delivery Events"
+  name = "${var.name}-ses-delivery-events-topic"
+  display_name = "${var.display_name} SES Delivery Events"
 
   delivery_policy = <<EOF
 {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -60,9 +60,26 @@ module "email" {
     "aws.email" = "aws.us-west-2"
   }
 
-  zone_id  = "${module.dns.primary_zone_id}"
-  domain   = "pypi.org"
-  hook_url = "https://pypi.org/_/ses-hook/"
+  name         = "pypi"
+  display_name = "PyPI"
+  zone_id      = "${module.dns.primary_zone_id}"
+  domain       = "pypi.org"
+  hook_url     = "https://pypi.org/_/ses-hook/"
+}
+
+
+module "testpypi-email" {
+  source = "./email"
+  providers = {
+    "aws" = "aws"
+    "aws.email" = "aws.us-west-2"
+  }
+
+  name         = "testpypi"
+  display_name = "TestPyPI"
+  zone_id      = "${module.dns.primary_zone_id}"
+  domain       = "test.pypi.org"
+  hook_url     = "https://test.pypi.org/_/ses-hook/"
 }
 
 
@@ -119,4 +136,5 @@ module "docs-hosting" {
 
 
 output "nameservers" { value = ["${module.dns.nameservers}"] }
-output "ses_delivery_topic" { value = "${module.email.delivery_topic}" }
+output "pypi-ses_delivery_topic" { value = "${module.email.delivery_topic}" }
+output "testpypi-ses_delivery_topic" { value = "${module.testpypi-email.delivery_topic}" }


### PR DESCRIPTION
```
Terraform will perform the following actions:

  + module.testpypi-email.aws_route53_record.primary_amazonses_dkim_record[0]
      id:                              <computed>
      allow_overwrite:                 "true"
      fqdn:                            <computed>
      name:                            "${element(aws_ses_domain_dkim.primary.dkim_tokens, count.index)}._domainkey.${var.domain}"
      records.#:                       <computed>
      ttl:                             "1800"
      type:                            "CNAME"
      zone_id:                         "Z2BIT24T5LM0F3"

  + module.testpypi-email.aws_route53_record.primary_amazonses_dkim_record[1]
      id:                              <computed>
      allow_overwrite:                 "true"
      fqdn:                            <computed>
      name:                            "${element(aws_ses_domain_dkim.primary.dkim_tokens, count.index)}._domainkey.${var.domain}"
      records.#:                       <computed>
      ttl:                             "1800"
      type:                            "CNAME"
      zone_id:                         "Z2BIT24T5LM0F3"

  + module.testpypi-email.aws_route53_record.primary_amazonses_dkim_record[2]
      id:                              <computed>
      allow_overwrite:                 "true"
      fqdn:                            <computed>
      name:                            "${element(aws_ses_domain_dkim.primary.dkim_tokens, count.index)}._domainkey.${var.domain}"
      records.#:                       <computed>
      ttl:                             "1800"
      type:                            "CNAME"
      zone_id:                         "Z2BIT24T5LM0F3"

  + module.testpypi-email.aws_route53_record.primary_amazonses_verification_record
      id:                              <computed>
      allow_overwrite:                 "true"
      fqdn:                            <computed>
      name:                            "_amazonses.test.pypi.org"
      records.#:                       <computed>
      ttl:                             "1800"
      type:                            "TXT"
      zone_id:                         "Z2BIT24T5LM0F3"

  + module.testpypi-email.aws_ses_domain_dkim.primary
      id:                              <computed>
      dkim_tokens.#:                   <computed>
      domain:                          "test.pypi.org"

  + module.testpypi-email.aws_ses_domain_identity.primary
      id:                              <computed>
      arn:                             <computed>
      domain:                          "test.pypi.org"
      verification_token:              <computed>

  + module.testpypi-email.aws_ses_identity_notification_topic.primary-bounces
      id:                              <computed>
      identity:                        "test.pypi.org"
      notification_type:               "Bounce"
      topic_arn:                       "${aws_sns_topic.delivery-events.arn}"

  + module.testpypi-email.aws_ses_identity_notification_topic.primary-complaints
      id:                              <computed>
      identity:                        "test.pypi.org"
      notification_type:               "Complaint"
      topic_arn:                       "${aws_sns_topic.delivery-events.arn}"

  + module.testpypi-email.aws_ses_identity_notification_topic.primary-deliveries
      id:                              <computed>
      identity:                        "test.pypi.org"
      notification_type:               "Delivery"
      topic_arn:                       "${aws_sns_topic.delivery-events.arn}"

  + module.testpypi-email.aws_sns_topic.delivery-events
      id:                              <computed>
      arn:                             <computed>
      delivery_policy:                 "{\"http\":{\"defaultHealthyRetryPolicy\":{\"backoffFunction\":\"exponential\",\"maxDelayTarget\":30,\"minDelayTarget\":5,\"numMaxDelayRetries\":25,\"numMinDelayRetries\":5,\"numNoDelayRetries\":5,\"numRetries\":100},\"disableSubscriptionOverrides\":false}}"
      display_name:                    "TestPyPI SES Delivery Events"
      name:                            "testpypi-ses-delivery-events-topic"
      policy:                          <computed>

  + module.testpypi-email.aws_sns_topic_subscription.delivery-events
      id:                              <computed>
      arn:                             <computed>
      confirmation_timeout_in_minutes: "1"
      endpoint:                        "https://test.pypi.org/_/ses-hook/"
      endpoint_auto_confirms:          "true"
      protocol:                        "https"
      raw_message_delivery:            "false"
      topic_arn:                       "${aws_sns_topic.delivery-events.arn}"


Plan: 11 to add, 0 to change, 0 to destroy.
```