### PR TITLE
Setup a SQS Queue for PyPI

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -86,6 +86,7 @@ module "testpypi-email" {
 module "pypi" {
   source = "./warehouse"
 
+  name            = "PyPI"
   zone_id         = "${module.dns.primary_zone_id}"
   domain          = "pypi.org"
   # Because of limitations of the Terraform fastly provider, there must be the same

--- a/terraform/warehouse/main.tf
+++ b/terraform/warehouse/main.tf
@@ -1,3 +1,4 @@
+variable "name" { type = "string" }
 variable "zone_id" { type = "string" }
 variable "domain" { type = "string" }
 variable "extra_domains" { type = "list" }

--- a/terraform/warehouse/worker.tf
+++ b/terraform/warehouse/worker.tf
@@ -1,0 +1,40 @@
+resource "aws_sqs_queue" "pypi_worker" {
+  name                       = "${lower(var.name)}-worker"
+  # We're going to set this to 5 minutes, which basically means that if a worker
+  # hasn't completed the task within 5 minutes, then SQS will make it visible for
+  # another work to accept it.
+  visibility_timeout_seconds = 300
+}
+
+
+resource "aws_iam_policy" "pypi_worker" {
+  name        = "${var.name}WorkerSQS"
+  description = "R/W Access to PyPI's SQS Worker Queue"
+
+  policy      = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "sqs:ListQueues"
+      ],
+     "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+          "sqs:DeleteMessage",
+          "sqs:GetQueueAttributes",
+          "sqs:GetQueueUrl",
+          "sqs:PurgeQueue",
+          "sqs:ReceiveMessage",
+          "sqs:SendMessage"
+      ],
+      "Resource": "${aws_sqs_queue.pypi_worker.arn}"
+    }
+  ]
+}
+EOF
+}


### PR DESCRIPTION
```
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  + module.pypi.aws_iam_policy.pypi_worker
      id:                                <computed>
      arn:                               <computed>
      description:                       "R/W Access to PyPI's SQS Worker Queue"
      name:                              "PyPIWorkerSQS"
      path:                              "/"
      policy:                            "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Effect\": \"Allow\",\n      \"Action\": [\n        \"sqs:ListQueues\"\n      ],\n     \"Resource\": \"*\"\n    },\n    {\n      \"Effect\": \"Allow\",\n      \"Action\": [\n          \"sqs:DeleteMessage\",\n          \"sqs:GetQueueAttributes\",\n          \"sqs:GetQueueUrl\",\n          \"sqs:PurgeQueue\",\n          \"sqs:ReceiveMessage\",\n          \"sqs:SendMessage\"\n      ],\n      \"Resource\": \"${aws_sqs_queue.pypi_worker.arn}\"\n    }\n  ]\n}\n"

  + module.pypi.aws_sqs_queue.pypi_worker
      id:                                <computed>
      arn:                               <computed>
      content_based_deduplication:       "false"
      delay_seconds:                     "0"
      fifo_queue:                        "false"
      kms_data_key_reuse_period_seconds: <computed>
      max_message_size:                  "262144"
      message_retention_seconds:         "345600"
      name:                              "pypi-worker"
      policy:                            <computed>
      receive_wait_time_seconds:         "0"
      visibility_timeout_seconds:        "300"


Plan: 2 to add, 0 to change, 0 to destroy.
```