### PR TITLE
restore prohibition against bandersnatch versions <1.4

### DIFF
--- a/terraform/warehouse/main.tf
+++ b/terraform/warehouse/main.tf
@@ -139,6 +139,14 @@ resource "fastly_service_v1" "pypi" {
     path           = "/pypi-org-errors/%Y/%m/%d/%H/%M/"
   }
 
+  response_object {
+    name = "Bandersnatch User-Agent prohibited"
+    status = 403
+    content = "Bandersnatch version no longer supported, upgrade to 1.4+"
+    content_type = "text/plain"
+    request_condition = "Bandersnatch User-Agent prohibited"
+  }
+
   condition {
     name      = "Primary Failure (Mirror-able)"
     type      = "REQUEST"
@@ -150,6 +158,12 @@ resource "fastly_service_v1" "pypi" {
     name = "5xx Error"
     type = "RESPONSE"
     statement = "(resp.status >= 500 && resp.status < 600)"
+  }
+
+  condition {
+    name = "Bandersnatch User-Agent prohibited"
+    type = "REQUEST"
+    statement = "req.http.user-agent ~ \"bandersnatch/1\\.(0|2|3)\""
   }
 }
 


### PR DESCRIPTION
This regressed when setting up the new service.

```
  ~ module.pypi.fastly_service_v1.pypi
      condition.#:                                  "2" => "3"
      condition.1122403973.name:                    "Primary Failure (Mirror-able)" => "Primary Failure (Mirror-able)"
      condition.1122403973.priority:                "1" => "1"
      condition.1122403973.statement:               "(!req.backend.healthy || req.restarts > 0) && (req.url ~ \"^/simple/\" || req.url ~ \"^/pypi/[^/]+(/[^/]+)?/json$\")" => "(!req.backend.healthy || req.restarts > 0) && (req.url ~ \"^/simple/\" || req.url ~ \"^/pypi/[^/]+(/[^/]+)?/json$\")"
      condition.1122403973.type:                    "REQUEST" => "REQUEST"
      condition.1505353239.name:                    "5xx Error" => "5xx Error"
      condition.1505353239.priority:                "10" => "10"
      condition.1505353239.statement:               "(resp.status >= 500 && resp.status < 600)" => "(resp.status >= 500 && resp.status < 600)"
      condition.1505353239.type:                    "RESPONSE" => "RESPONSE"
      condition.1559177719.name:                    "" => "Bandersnatch User-Agent prohibited"
      condition.1559177719.priority:                "" => "10"
      condition.1559177719.statement:               "" => "req.http.user-agent ~ \"bandersnatch/1\\.(0|2|3)\""
      condition.1559177719.type:                    "" => "REQUEST"
      response_object.#:                            "0" => "1"
      response_object.2869758694.cache_condition:   "" => ""
      response_object.2869758694.content:           "" => "Bandersnatch version no longer supported, upgrade to 1.4+"
      response_object.2869758694.content_type:      "" => "text/plain"
      response_object.2869758694.name:              "" => "Bandersnatch User-Agent prohibited"
      response_object.2869758694.request_condition: "" => "Bandersnatch User-Agent prohibited"
      response_object.2869758694.response:          "" => "OK"
      response_object.2869758694.status:            "" => "403"


Plan: 0 to add, 1 to change, 0 to destroy.
```