### PR TITLE
Move Amazon SES SPF headers to the correct domain

### DIFF
--- a/terraform/email/main.tf
+++ b/terraform/email/main.tf
@@ -70,6 +70,14 @@ resource "aws_route53_record" "primary_amazonses_mx_record" {
   records = ["10 feedback-smtp.${data.aws_region.mail_region.name}.amazonses.com"]
 }
 
+resource "aws_route53_record" "primary_amazonses_spf_record" {
+  zone_id = "${var.zone_id}"
+  name = "${aws_ses_domain_mail_from.primary.mail_from_domain}"
+  type = "TXT"
+  ttl = "600"
+  records = ["v=spf1 include:amazonses.com -all"]
+}
+
 
 resource "aws_sns_topic" "delivery-events" {
   provider = "aws.email"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -44,7 +44,7 @@ module "dns" {
   apex_txt = [
     "google-site-verification=YdrllWIiutXFzqhEamHP4HgCoh88dTFzb2A6QFljooc",
     "google-site-verification=ZI8zeHE6SWuJljW3f4csGetjOWo4krvjf13tdORsH4Y",
-    "v=spf1 include:_spf.google.com include:amazonses.com -all"
+    "v=spf1 include:_spf.google.com -all"
   ]
 }
 


### PR DESCRIPTION
```
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create
  ~ update in-place

Terraform will perform the following actions:

  ~ module.dns.aws_route53_record.apex_txt
      records.1535138413: "google-site-verification=YdrllWIiutXFzqhEamHP4HgCoh88dTFzb2A6QFljooc" => "google-site-verification=YdrllWIiutXFzqhEamHP4HgCoh88dTFzb2A6QFljooc"
      records.689124498:  "v=spf1 include:_spf.google.com include:amazonses.com -all" => ""
      records.760501546:  "" => "v=spf1 include:_spf.google.com -all"
      records.831471624:  "google-site-verification=ZI8zeHE6SWuJljW3f4csGetjOWo4krvjf13tdORsH4Y" => "google-site-verification=ZI8zeHE6SWuJljW3f4csGetjOWo4krvjf13tdORsH4Y"

  + module.email.aws_route53_record.primary_amazonses_spf_record
      id:                 <computed>
      allow_overwrite:    "true"
      fqdn:               <computed>
      name:               "ses.pypi.org"
      records.#:          "1"
      records.3464451788: "v=spf1 include:amazonses.com -all"
      ttl:                "600"
      type:               "TXT"
      zone_id:            "..."

  + module.testpypi-email.aws_route53_record.primary_amazonses_spf_record
      id:                 <computed>
      allow_overwrite:    "true"
      fqdn:               <computed>
      name:               "ses.test.pypi.org"
      records.#:          "1"
      records.3464451788: "v=spf1 include:amazonses.com -all"
      ttl:                "600"
      type:               "TXT"
      zone_id:            "..."


Plan: 2 to add, 1 to change, 0 to destroy.

------------------------------------------------------------------------

Note: You didn't specify an "-out" parameter to save this plan, so Terraform
can't guarantee that exactly these actions will be performed if
"terraform apply" is subsequently run.
```