### PR TITLE
Handle locales

### DIFF
--- a/terraform/warehouse/vcl/main.vcl
+++ b/terraform/warehouse/vcl/main.vcl
@@ -59,6 +59,11 @@ sub vcl_recv {
     # thing, reducing cache misses due to ordering differences.
     set req.url = boltsort.sort(req.url);
 
+    # Synthesize a custom header for the locale if set, so we can vary on this
+    # instead of the entire cookie
+    if (req.http.Cookie:_LOCALE_) {
+        set req.http.PyPI-Locale = req.http.Cookie:_LOCALE_;
+    }
 
 #FASTLY recv
 

--- a/terraform/warehouse/vcl/main.vcl
+++ b/terraform/warehouse/vcl/main.vcl
@@ -39,6 +39,7 @@ sub vcl_recv {
     # This will match any URL except those that start with:
     #
     #   * /admin/
+    #   * /locale/
     #   * /manage/
     #   * /search/
     #   * /account/login/
@@ -49,7 +50,7 @@ sub vcl_recv {
     #   * /account/two-factor/
     #   * /account/webauthn-authenticate/
     #   * /pypi
-    if (req.url.path !~ "^/(admin/|manage/|search(/|$)|account/(login|logout|register|reset-password|verify-email|two-factor|webauthn-authenticate)/|pypi)") {
+    if (req.url.path !~ "^/(admin/|locale/|manage/|search(/|$)|account/(login|logout|register|reset-password|verify-email|two-factor|webauthn-authenticate)/|pypi)") {
         set req.url = req.url.path;
     }
 


### PR DESCRIPTION
Pairs nicely with https://github.com/pypa/warehouse/pull/6802.

Prevents query parameters from being stripped from `/locale/` and adds a synthetic `PyPI-Locale` header which we can vary on.

References:
* https://www.fastly.com/blog/best-practices-using-vary-header
* https://support.fastly.com/hc/en-us/community/posts/360040444812-Pull-cookie-values-without-regular-expressions