### PR TITLE
default PyPI-Locale header to english

### DIFF
--- a/terraform/warehouse/vcl/main.vcl
+++ b/terraform/warehouse/vcl/main.vcl
@@ -64,6 +64,10 @@ sub vcl_recv {
     if (req.http.Cookie:_LOCALE_) {
         set req.http.PyPI-Locale = req.http.Cookie:_LOCALE_;
     }
+    else {
+        # Default to english for cached content
+        set req.http.PyPI-Locale = "en";
+    }
 
 #FASTLY recv
 


### PR DESCRIPTION
Without a default the first language to load a page became the default if no locale is set