### PR TITLE
Hide Vary: PyPI-Locale from downstream, Vary on Cookie

### DIFF
--- a/terraform/warehouse/vcl/main.vcl
+++ b/terraform/warehouse/vcl/main.vcl
@@ -295,6 +295,11 @@ sub vcl_deliver {
 
 #FASTLY deliver
 
+    # Hide the existence of PyPI-Locale header from downstream
+    if (resp.http.Vary && !req.http.Fastly-FF) {
+        set resp.http.Vary = regsub(resp.http.Vary, "PyPI-Locale", "Cookie");
+    }
+
     # Unset headers that we don't need/want to send on to the client because
     # they are not generally useful.
     unset resp.http.Via;


### PR DESCRIPTION
This should hide the existence of PyPI-Locale in the Vary header from end users, without impacting shields.