### PR TITLE
bump DNS ttls

### DIFF
--- a/terraform/dns/main.tf
+++ b/terraform/dns/main.tf
@@ -19,7 +19,7 @@ resource "aws_route53_record" "caa" {
     zone_id = "${aws_route53_zone.primary.zone_id}"
     name    = "${var.primary_domain}"
     type    = "CAA"
-    ttl     = 1800
+    ttl     = 60
     records = "${concat(formatlist("0 issue \"%s\"", var.caa_issuers), list("0 iodef \"${var.caa_report_uri}\""))}"
 }
 
@@ -27,7 +27,7 @@ resource "aws_route53_record" "apex_txt" {
   zone_id = "${aws_route53_zone.primary.zone_id}"
   name    = "${var.primary_domain}"
   type    = "TXT"
-  ttl     = 1800
+  ttl     = 60
   records = "${var.apex_txt}"
 }
 
@@ -42,7 +42,7 @@ resource "aws_route53_record" "user_content_caa" {
     zone_id = "${aws_route53_zone.user_content.zone_id}"
     name    = "${var.user_content_domain}"
     type    = "CAA"
-    ttl     = 1800
+    ttl     = 60
     records = "${concat(formatlist("0 issue \"%s\"", var.caa_issuers), list("0 iodef \"${var.caa_report_uri}\""))}"
 }
 

--- a/terraform/dns/main.tf
+++ b/terraform/dns/main.tf
@@ -19,7 +19,7 @@ resource "aws_route53_record" "caa" {
     zone_id = "${aws_route53_zone.primary.zone_id}"
     name    = "${var.primary_domain}"
     type    = "CAA"
-    ttl     = 60
+    ttl     = 1800
     records = "${concat(formatlist("0 issue \"%s\"", var.caa_issuers), list("0 iodef \"${var.caa_report_uri}\""))}"
 }
 
@@ -27,7 +27,7 @@ resource "aws_route53_record" "apex_txt" {
   zone_id = "${aws_route53_zone.primary.zone_id}"
   name    = "${var.primary_domain}"
   type    = "TXT"
-  ttl     = 60
+  ttl     = 1800
   records = "${var.apex_txt}"
 }
 
@@ -42,7 +42,7 @@ resource "aws_route53_record" "user_content_caa" {
     zone_id = "${aws_route53_zone.user_content.zone_id}"
     name    = "${var.user_content_domain}"
     type    = "CAA"
-    ttl     = 60
+    ttl     = 1800
     records = "${concat(formatlist("0 issue \"%s\"", var.caa_issuers), list("0 iodef \"${var.caa_report_uri}\""))}"
 }
 

--- a/terraform/docs-hosting/main.tf
+++ b/terraform/docs-hosting/main.tf
@@ -43,7 +43,7 @@ resource "aws_route53_record" "docs" {
   zone_id = "${var.zone_id}"
   name    = "${var.domain}"
   type    = "${local.apex_domain ? "A" : "CNAME"}"
-  ttl     = 60
+  ttl     = 1800
   records = ["${var.fastly_endpoints["${join("_", list(var.domain_map[var.domain], local.apex_domain ? "A" : "CNAME"))}"]}"]
 }
 
@@ -54,6 +54,6 @@ resource "aws_route53_record" "docs-ipv6" {
   zone_id = "${var.zone_id}"
   name    = "${var.domain}"
   type    = "AAAA"
-  ttl     = 60
+  ttl     = 1800
   records = ["${var.fastly_endpoints["${join("_", list(var.domain_map[var.domain], "AAAA"))}"]}"]
 }

--- a/terraform/docs-hosting/main.tf
+++ b/terraform/docs-hosting/main.tf
@@ -43,7 +43,7 @@ resource "aws_route53_record" "docs" {
   zone_id = "${var.zone_id}"
   name    = "${var.domain}"
   type    = "${local.apex_domain ? "A" : "CNAME"}"
-  ttl     = 1800
+  ttl     = 3600
   records = ["${var.fastly_endpoints["${join("_", list(var.domain_map[var.domain], local.apex_domain ? "A" : "CNAME"))}"]}"]
 }
 
@@ -54,6 +54,6 @@ resource "aws_route53_record" "docs-ipv6" {
   zone_id = "${var.zone_id}"
   name    = "${var.domain}"
   type    = "AAAA"
-  ttl     = 1800
+  ttl     = 3600
   records = ["${var.fastly_endpoints["${join("_", list(var.domain_map[var.domain], "AAAA"))}"]}"]
 }

--- a/terraform/email/main.tf
+++ b/terraform/email/main.tf
@@ -58,7 +58,7 @@ resource "aws_route53_record" "primary_amazonses_dmarc_record" {
   zone_id = "${var.zone_id}"
   name    = "_dmarc.${var.domain}"
   type    = "TXT"
-  ttl     = "60"
+  ttl     = "1800"
   records = ["v=DMARC1; p=none; rua=${var.dmarc}; fo=1; adkim=s; aspf=r"]
 }
 
@@ -66,7 +66,7 @@ resource "aws_route53_record" "primary_amazonses_mx_record" {
   zone_id = "${var.zone_id}"
   name    = "${aws_ses_domain_mail_from.primary.mail_from_domain}"
   type    = "MX"
-  ttl     = "600"
+  ttl     = "1800"
   records = ["10 feedback-smtp.${data.aws_region.mail_region.name}.amazonses.com"]
 }
 
@@ -74,7 +74,7 @@ resource "aws_route53_record" "primary_amazonses_spf_record" {
   zone_id = "${var.zone_id}"
   name = "${aws_ses_domain_mail_from.primary.mail_from_domain}"
   type = "TXT"
-  ttl = "600"
+  ttl = "1800"
   records = ["v=spf1 include:amazonses.com -all"]
 }
 

--- a/terraform/file-hosting/main.tf
+++ b/terraform/file-hosting/main.tf
@@ -179,7 +179,7 @@ resource "aws_route53_record" "files" {
   zone_id = "${var.zone_id}"
   name    = "${var.domain}"
   type    = "${local.apex_domain ? "A" : "CNAME"}"
-  ttl     = 1800
+  ttl     = 3600
   records = ["${var.fastly_endpoints["${join("_", list(var.domain_map[var.domain], local.apex_domain ? "A" : "CNAME"))}"]}"]
 }
 
@@ -190,6 +190,6 @@ resource "aws_route53_record" "files-ipv6" {
   zone_id = "${var.zone_id}"
   name    = "${var.domain}"
   type    = "AAAA"
-  ttl     = 1800
+  ttl     = 3600
   records = ["${var.fastly_endpoints["${join("_", list(var.domain_map[var.domain], "AAAA"))}"]}"]
 }

--- a/terraform/file-hosting/main.tf
+++ b/terraform/file-hosting/main.tf
@@ -179,7 +179,7 @@ resource "aws_route53_record" "files" {
   zone_id = "${var.zone_id}"
   name    = "${var.domain}"
   type    = "${local.apex_domain ? "A" : "CNAME"}"
-  ttl     = 60
+  ttl     = 1800
   records = ["${var.fastly_endpoints["${join("_", list(var.domain_map[var.domain], local.apex_domain ? "A" : "CNAME"))}"]}"]
 }
 
@@ -190,6 +190,6 @@ resource "aws_route53_record" "files-ipv6" {
   zone_id = "${var.zone_id}"
   name    = "${var.domain}"
   type    = "AAAA"
-  ttl     = 60
+  ttl     = 1800
   records = ["${var.fastly_endpoints["${join("_", list(var.domain_map[var.domain], "AAAA"))}"]}"]
 }

--- a/terraform/warehouse/main.tf
+++ b/terraform/warehouse/main.tf
@@ -198,7 +198,7 @@ resource "aws_route53_record" "primary" {
   zone_id = "${var.zone_id}"
   name    = "${var.domain}"
   type    = "${local.apex_domain ? "A" : "CNAME"}"
-  ttl     = 60
+  ttl     = 1800
   records = ["${var.fastly_endpoints["${join("_", list(var.domain_map[var.domain], local.apex_domain ? "A" : "CNAME"))}"]}"]
 }
 
@@ -208,6 +208,6 @@ resource "aws_route53_record" "primary-ipv6" {
   zone_id = "${var.zone_id}"
   name    = "${var.domain}"
   type    = "AAAA"
-  ttl     = 60
+  ttl     = 1800
   records = ["${var.fastly_endpoints["${join("_", list(var.domain_map[var.domain], "AAAA"))}"]}"]
 }

--- a/terraform/warehouse/main.tf
+++ b/terraform/warehouse/main.tf
@@ -198,7 +198,7 @@ resource "aws_route53_record" "primary" {
   zone_id = "${var.zone_id}"
   name    = "${var.domain}"
   type    = "${local.apex_domain ? "A" : "CNAME"}"
-  ttl     = 1800
+  ttl     = 3600
   records = ["${var.fastly_endpoints["${join("_", list(var.domain_map[var.domain], local.apex_domain ? "A" : "CNAME"))}"]}"]
 }
 
@@ -208,6 +208,6 @@ resource "aws_route53_record" "primary-ipv6" {
   zone_id = "${var.zone_id}"
   name    = "${var.domain}"
   type    = "AAAA"
-  ttl     = 1800
+  ttl     = 3600
   records = ["${var.fastly_endpoints["${join("_", list(var.domain_map[var.domain], "AAAA"))}"]}"]
 }


### PR DESCRIPTION
We had just over a billion DNS queries in December which is ~$400 in credit usage for AWS.

This should reduce our DNS spend by a pretty penny, but could probably be pushed out to an hour or so for many of the higher volume endpoints.