### PR TITLE
Start migration to GCP based linehaul

### DIFF
--- a/terraform/file-hosting/vcl/main.vcl
+++ b/terraform/file-hosting/vcl/main.vcl
@@ -223,6 +223,7 @@ sub vcl_deliver {
 
         # And we want to log an event stating that a download has taken place.
         log {"syslog "} req.service_id {" linehaul :: "} "2@" now "|" geoip.country_code "|" req.url.path "|" tls.client.protocol "|" tls.client.cipher "|" resp.http.x-amz-meta-project "|" resp.http.x-amz-meta-version "|" resp.http.x-amz-meta-package-type "|" req.http.user-agent;
+        log {"syslog "} req.service_id {" Linehaul GCS :: "} "download|" now "|" geoip.country_code "|" req.url.path "|" tls.client.protocol "|" tls.client.cipher "|" resp.http.x-amz-meta-project "|" resp.http.x-amz-meta-version "|" resp.http.x-amz-meta-package-type "|" req.http.user-agent;
     }
 
     # Unset a few headers set by Amazon/Google that we don't really have a need/desire

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,6 @@
 variable "linehaul_token" { type = "string" }
 variable "linehaul_creds" { type = "string" }
+variable "linehaul_gcs_private_key" { type = "string" }
 variable "fastly_s3_logging" { type = "map" }
 
 locals {
@@ -130,6 +131,11 @@ module "file-hosting" {
     address = "linehaul.nyc1.psf.io"
     port    = 48175
     token   = "${var.linehaul_token}"
+  }
+  linehaul_gcs = {
+    bucket      = "linehaul-logs"
+    email       = "linehaul-logs@the-psf.iam.gserviceaccount.com"
+    private_key = "${var.linehaul_gcs_private_key}"
   }
 
   fastly_endpoints = "${local.fastly_endpoints}"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -108,8 +108,13 @@ module "pypi" {
   extra_domains   = ["www.pypi.org", "pypi.python.org", "pypi.io", "www.pypi.io", "warehouse.python.org"]
   backend         = "warehouse.cmh1.psfhosted.org"
   mirror          = "mirror.dub1.pypi.io"
-  linehaul_bucket = "linehaul-logs"
   s3_logging_keys = "${var.fastly_s3_logging}"
+
+  linehaul_gcs = {
+    bucket      = "linehaul-logs"
+    email       = "linehaul-logs@the-psf.iam.gserviceaccount.com"
+    private_key = "${var.linehaul_gcs_private_key}"
+  }
 
   fastly_endpoints = "${local.fastly_endpoints}"
   domain_map       = "${local.domain_map}"

--- a/terraform/warehouse/vcl/main.vcl
+++ b/terraform/warehouse/vcl/main.vcl
@@ -318,16 +318,6 @@ sub vcl_deliver {
     # https://tools.ietf.org/html/rfc7234#section-4.2.3
     unset resp.http.Age;
 
-    # If we're not executing a shielding request, and the URL is one of our file
-    # URLs, and it's a GET request, and the response is either a 200 or a 304
-    # then we want to log an event stating that a download has taken place.
-    if (!req.http.Fastly-FF
-            && req.url.path ~ "^/simple/.+/"
-            && req.request == "GET"
-            && http_status_matches(resp.status, "200,304")) {
-        log {"syslog "} req.service_id {" linehaul :: "} "3@" "simple" "|" now "|" geoip.country_code "|" req.url.path "|" tls.client.protocol "|" tls.client.cipher "|" req.http.user-agent;
-    }
-
     # Set our standard security headers, we do this in VCL rather than in
     # Warehouse itself so that we always get these headers, regardless of the
     # origin server being used.


### PR DESCRIPTION
This starts shipping our Linehaul logs to Google Storage instead of S3.

This immediately transitions `pypi.simple_requests` to be fed by the new Cloud Function, no migration or anything interesting is needed here... Fastly will stop shipping logs to the S3 bucket and start sending them to the Google Storage bucket. Since the table is partitioned/clustered we don't have to do any careful handling.

This will _begin_ feeding the new partitioned/clustered `pypi.file_downloads` table. At some day boundary I can clear out this new table for anything older and begin backfilling from the `pypi.downloadsYYYYMMDD` tables.

Eventually we can stop feeding the current syslog linehaul consumer, deprecate the old sharded tables etc.