### PR TITLE
ease up our health check for pypi backends

### DIFF
--- a/terraform/warehouse/main.tf
+++ b/terraform/warehouse/main.tf
@@ -82,8 +82,8 @@ resource "fastly_service_v1" "pypi" {
     method = "GET"
     path   = "/_health/"
 
-    check_interval = 3000
-    timeout = 2000
+    check_interval = 6000
+    timeout = 4000
     threshold = 2
     initial = 2
     window = 4


### PR DESCRIPTION
BOM has been having trouble with 'unhealthy backends'

AFAICT this is not the pypi backends themselves slowing down or failing health checks :/