### PR TITLE
upgrade terraform to latest

### DIFF
--- a/terraform/config.tf
+++ b/terraform/config.tf
@@ -1,6 +1,35 @@
-variable "credentials" { type = map(any) }
-variable "linehaul_token" { type = string }
-variable "linehaul_creds" { type = string }
+variable "credentials" {
+  type      = map(any)
+  sensitive = true
+}
+variable "linehaul_token" {
+  type      = string
+  sensitive = true
+}
+variable "linehaul_creds" {
+  type      = string
+  sensitive = true
+}
+variable "aws_access_key_id" {
+  type      = string
+  sensitive = true
+}
+variable "aws_secret_access_key" {
+  type      = string
+  sensitive = true
+}
+variable "gcs_access_key_id" {
+  type      = string
+  sensitive = true
+}
+variable "gcs_secret_access_key" {
+  type      = string
+  sensitive = true
+}
+variable "warehouse_token" {
+  type      = string
+  sensitive = true
+}
 
 
 terraform {

--- a/terraform/config.tf
+++ b/terraform/config.tf
@@ -1,4 +1,4 @@
-variable "credentials" { type = map }
+variable "credentials" { type = map(any) }
 variable "linehaul_token" { type = string }
 variable "linehaul_creds" { type = string }
 

--- a/terraform/config.tf
+++ b/terraform/config.tf
@@ -1,25 +1,6 @@
-variable "credentials" { type = "map" }
-
-
-provider "aws" {
-  version = "~> 1.51"
-  region  = "us-east-2"
-  profile = "psf-prod"
-}
-
-
-provider "aws" {
-  version = "~> 1.51"
-  alias   = "us-west-2"
-  region  = "us-west-2"
-  profile = "psf-prod"
-}
-
-
-provider "fastly" {
-  version = "~> 0.3.0"
-  api_key = "${var.credentials["fastly"]}"
-}
+variable "credentials" { type = map }
+variable "linehaul_token" { type = string }
+variable "linehaul_creds" { type = string }
 
 
 terraform {
@@ -30,4 +11,29 @@ terraform {
     dynamodb_table = "pypi-infra-terraform-locks"
     profile        = "psf-prod"
   }
+}
+
+
+provider "aws" {
+  alias   = "us-east-2"
+  region  = "us-east-2"
+  profile = "psf-prod"
+}
+
+
+provider "aws" {
+  alias   = "us-west-2"
+  region  = "us-west-2"
+  profile = "psf-prod"
+}
+
+provider "aws" {
+  alias   = "email"
+  region  = "us-west-2"
+  profile = "psf-prod"
+}
+
+
+provider "fastly" {
+  api_key = var.credentials["fastly"]
 }

--- a/terraform/dns/main.tf
+++ b/terraform/dns/main.tf
@@ -1,9 +1,18 @@
-variable "tags" { type = "map" }
-variable "primary_domain" { type = "string" }
-variable "user_content_domain" { type = "string" }
-variable "caa_report_uri" { type = "string" }
-variable "caa_issuers" { type = "list" }
-variable "apex_txt" { type = "list" }
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 0.13"
+}
+
+variable "tags" { type = map }
+variable "primary_domain" { type = string }
+variable "user_content_domain" { type = string }
+variable "caa_report_uri" { type = string }
+variable "caa_issuers" { type = list }
+variable "apex_txt" { type = list }
 
 
 resource "aws_route53_delegation_set" "ns" {}
@@ -20,7 +29,7 @@ resource "aws_route53_record" "caa" {
     name    = "${var.primary_domain}"
     type    = "CAA"
     ttl     = 3600
-    records = "${concat(formatlist("0 issue \"%s\"", var.caa_issuers), list("0 iodef \"${var.caa_report_uri}\""))}"
+    records = concat(formatlist("0 issue \"%s\"", var.caa_issuers), ["0 iodef \"${var.caa_report_uri}\""])
 }
 
 resource "aws_route53_record" "apex_txt" {
@@ -43,7 +52,7 @@ resource "aws_route53_record" "user_content_caa" {
     name    = "${var.user_content_domain}"
     type    = "CAA"
     ttl     = 3600
-    records = "${concat(formatlist("0 issue \"%s\"", var.caa_issuers), list("0 iodef \"${var.caa_report_uri}\""))}"
+    records = concat(formatlist("0 issue \"%s\"", var.caa_issuers), ["0 iodef \"${var.caa_report_uri}\""])
 }
 
 

--- a/terraform/dns/main.tf
+++ b/terraform/dns/main.tf
@@ -7,55 +7,55 @@ terraform {
   required_version = ">= 0.13"
 }
 
-variable "tags" { type = map }
+variable "tags" { type = map(any) }
 variable "primary_domain" { type = string }
 variable "user_content_domain" { type = string }
 variable "caa_report_uri" { type = string }
-variable "caa_issuers" { type = list }
-variable "apex_txt" { type = list }
+variable "caa_issuers" { type = list(any) }
+variable "apex_txt" { type = list(any) }
 
 
 resource "aws_route53_delegation_set" "ns" {}
 
 
 resource "aws_route53_zone" "primary" {
-  name              = "${var.primary_domain}"
-  delegation_set_id = "${aws_route53_delegation_set.ns.id}"
-  tags              = "${var.tags}"
+  name              = var.primary_domain
+  delegation_set_id = aws_route53_delegation_set.ns.id
+  tags              = var.tags
 }
 
 resource "aws_route53_record" "caa" {
-    zone_id = "${aws_route53_zone.primary.zone_id}"
-    name    = "${var.primary_domain}"
-    type    = "CAA"
-    ttl     = 3600
-    records = concat(formatlist("0 issue \"%s\"", var.caa_issuers), ["0 iodef \"${var.caa_report_uri}\""])
+  zone_id = aws_route53_zone.primary.zone_id
+  name    = var.primary_domain
+  type    = "CAA"
+  ttl     = 3600
+  records = concat(formatlist("0 issue \"%s\"", var.caa_issuers), ["0 iodef \"${var.caa_report_uri}\""])
 }
 
 resource "aws_route53_record" "apex_txt" {
-  zone_id = "${aws_route53_zone.primary.zone_id}"
-  name    = "${var.primary_domain}"
+  zone_id = aws_route53_zone.primary.zone_id
+  name    = var.primary_domain
   type    = "TXT"
   ttl     = 3600
-  records = "${var.apex_txt}"
+  records = var.apex_txt
 }
 
 
 resource "aws_route53_zone" "user_content" {
-  name              = "${var.user_content_domain}"
-  delegation_set_id = "${aws_route53_delegation_set.ns.id}"
-  tags              = "${var.tags}"
+  name              = var.user_content_domain
+  delegation_set_id = aws_route53_delegation_set.ns.id
+  tags              = var.tags
 }
 
 resource "aws_route53_record" "user_content_caa" {
-    zone_id = "${aws_route53_zone.user_content.zone_id}"
-    name    = "${var.user_content_domain}"
-    type    = "CAA"
-    ttl     = 3600
-    records = concat(formatlist("0 issue \"%s\"", var.caa_issuers), ["0 iodef \"${var.caa_report_uri}\""])
+  zone_id = aws_route53_zone.user_content.zone_id
+  name    = var.user_content_domain
+  type    = "CAA"
+  ttl     = 3600
+  records = concat(formatlist("0 issue \"%s\"", var.caa_issuers), ["0 iodef \"${var.caa_report_uri}\""])
 }
 
 
 output "nameservers" { value = ["${aws_route53_delegation_set.ns.name_servers}"] }
-output "primary_zone_id" { value = "${aws_route53_zone.primary.zone_id}" }
-output "user_content_zone_id" { value = "${aws_route53_zone.user_content.zone_id}" }
+output "primary_zone_id" { value = aws_route53_zone.primary.zone_id }
+output "user_content_zone_id" { value = aws_route53_zone.user_content.zone_id }

--- a/terraform/dns/main.tf
+++ b/terraform/dns/main.tf
@@ -56,6 +56,6 @@ resource "aws_route53_record" "user_content_caa" {
 }
 
 
-output "nameservers" { value = ["${aws_route53_delegation_set.ns.name_servers}"] }
+output "nameservers" { value = aws_route53_delegation_set.ns.name_servers }
 output "primary_zone_id" { value = aws_route53_zone.primary.zone_id }
 output "user_content_zone_id" { value = aws_route53_zone.user_content.zone_id }

--- a/terraform/docs-hosting/main.tf
+++ b/terraform/docs-hosting/main.tf
@@ -13,6 +13,7 @@ locals {
 
 
 resource "fastly_service_vcl" "docs" {
+  activate    = false
   name        = "${var.sitename} Docs Hosting"
   default_ttl = 86400 # 1 day
 

--- a/terraform/docs-hosting/main.tf
+++ b/terraform/docs-hosting/main.tf
@@ -13,7 +13,8 @@ locals {
 
 
 resource "fastly_service_vcl" "docs" {
-  activate    = false
+  # Set to false for spicy changes
+  activate = true
   name        = "${var.sitename} Docs Hosting"
   default_ttl = 86400 # 1 day
 

--- a/terraform/docs-hosting/main.tf
+++ b/terraform/docs-hosting/main.tf
@@ -1,10 +1,10 @@
 variable "sitename" { default = "PyPI" }
-variable "zone_id" { type = "string" }
-variable "domain" { type = "string" }
-variable "conveyor_address" { type = "string" }
+variable "zone_id" { type = string }
+variable "domain" { type = string }
+variable "conveyor_address" { type = string }
 
-variable "fastly_endpoints" { type = "map" }
-variable "domain_map" { type = "map" }
+variable "fastly_endpoints" { type = map }
+variable "domain_map" { type = map }
 
 
 locals {
@@ -12,7 +12,7 @@ locals {
 }
 
 
-resource "fastly_service_v1" "docs" {
+resource "fastly_service_vcl" "docs" {
   name        = "${var.sitename} Docs Hosting"
   default_ttl = 86400  # 1 day
 
@@ -44,7 +44,7 @@ resource "aws_route53_record" "docs" {
   name    = "${var.domain}"
   type    = "${local.apex_domain ? "A" : "CNAME"}"
   ttl     = 86400
-  records = ["${var.fastly_endpoints["${join("_", list(var.domain_map[var.domain], local.apex_domain ? "A" : "CNAME"))}"]}"]
+  records = var.fastly_endpoints[join("_", [var.domain_map[var.domain], local.apex_domain ? "A" : "CNAME"])]
 }
 
 
@@ -55,5 +55,5 @@ resource "aws_route53_record" "docs-ipv6" {
   name    = "${var.domain}"
   type    = "AAAA"
   ttl     = 86400
-  records = ["${var.fastly_endpoints["${join("_", list(var.domain_map[var.domain], "AAAA"))}"]}"]
+  records = var.fastly_endpoints[join("_", [var.domain_map[var.domain], "AAAA"])]
 }

--- a/terraform/docs-hosting/main.tf
+++ b/terraform/docs-hosting/main.tf
@@ -19,8 +19,9 @@ resource "fastly_service_vcl" "docs" {
   domain { name = var.domain }
 
   backend {
-    name   = "Conveyor"
-    shield = "iad-va-us"
+    name             = "Conveyor"
+    shield           = "iad-va-us"
+    auto_loadbalance = true
 
     address           = var.conveyor_address
     port              = 443

--- a/terraform/docs-hosting/main.tf
+++ b/terraform/docs-hosting/main.tf
@@ -3,56 +3,56 @@ variable "zone_id" { type = string }
 variable "domain" { type = string }
 variable "conveyor_address" { type = string }
 
-variable "fastly_endpoints" { type = map }
-variable "domain_map" { type = map }
+variable "fastly_endpoints" { type = map(any) }
+variable "domain_map" { type = map(any) }
 
 
 locals {
-  apex_domain = "${length(split(".", var.domain)) > 2 ? false : true}"
+  apex_domain = length(split(".", var.domain)) > 2 ? false : true
 }
 
 
 resource "fastly_service_vcl" "docs" {
   name        = "${var.sitename} Docs Hosting"
-  default_ttl = 86400  # 1 day
+  default_ttl = 86400 # 1 day
 
-  domain { name = "${var.domain}" }
+  domain { name = var.domain }
 
   backend {
-    name              = "Conveyor"
-    shield            = "iad-va-us"
+    name   = "Conveyor"
+    shield = "iad-va-us"
 
-    address           = "${var.conveyor_address}"
+    address           = var.conveyor_address
     port              = 443
     use_ssl           = true
-    ssl_cert_hostname = "${var.conveyor_address}"
-    ssl_sni_hostname  = "${var.conveyor_address}"
+    ssl_cert_hostname = var.conveyor_address
+    ssl_sni_hostname  = var.conveyor_address
   }
 
   gzip { name = "Default GZIP Policy" }
 
   vcl {
     name    = "Main"
-    content = "${file("${path.module}/vcl/main.vcl")}"
+    content = file("${path.module}/vcl/main.vcl")
     main    = true
   }
 }
 
 
 resource "aws_route53_record" "docs" {
-  zone_id = "${var.zone_id}"
-  name    = "${var.domain}"
-  type    = "${local.apex_domain ? "A" : "CNAME"}"
+  zone_id = var.zone_id
+  name    = var.domain
+  type    = local.apex_domain ? "A" : "CNAME"
   ttl     = 86400
   records = var.fastly_endpoints[join("_", [var.domain_map[var.domain], local.apex_domain ? "A" : "CNAME"])]
 }
 
 
 resource "aws_route53_record" "docs-ipv6" {
-  count = "${local.apex_domain ? 1 : 0}"
+  count = local.apex_domain ? 1 : 0
 
-  zone_id = "${var.zone_id}"
-  name    = "${var.domain}"
+  zone_id = var.zone_id
+  name    = var.domain
   type    = "AAAA"
   ttl     = 86400
   records = var.fastly_endpoints[join("_", [var.domain_map[var.domain], "AAAA"])]

--- a/terraform/docs-hosting/versions.tf
+++ b/terraform/docs-hosting/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    fastly = {
+      source = "fastly/fastly"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/terraform/email/main.tf
+++ b/terraform/email/main.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      configuration_aliases = [ aws.email ]
+      source                = "hashicorp/aws"
+      configuration_aliases = [aws.email]
     }
   }
 }
@@ -19,7 +19,7 @@ variable "domain" { type = string }
 variable "zone_id" { type = string }
 variable "hook_url" { type = string }
 variable "dmarc" {
-  type = string
+  type    = string
   default = ""
 }
 
@@ -30,24 +30,24 @@ data "aws_region" "mail_region" {
 
 resource "aws_ses_domain_identity" "primary" {
   provider = aws.email
-  domain   = "${var.domain}"
+  domain   = var.domain
 }
 
 
 resource "aws_ses_domain_dkim" "primary" {
   provider = aws.email
-  domain = "${aws_ses_domain_identity.primary.domain}"
+  domain   = aws_ses_domain_identity.primary.domain
 }
 
 resource "aws_ses_domain_mail_from" "primary" {
-  provider = aws.email
-  domain = "${aws_ses_domain_identity.primary.domain}"
+  provider         = aws.email
+  domain           = aws_ses_domain_identity.primary.domain
   mail_from_domain = "ses.${aws_ses_domain_identity.primary.domain}"
 }
 
 
 resource "aws_route53_record" "primary_amazonses_verification_record" {
-  zone_id = "${var.zone_id}"
+  zone_id = var.zone_id
   name    = "_amazonses.${var.domain}"
   type    = "TXT"
   ttl     = "3600"
@@ -57,7 +57,7 @@ resource "aws_route53_record" "primary_amazonses_verification_record" {
 
 resource "aws_route53_record" "primary_amazonses_dkim_record" {
   count   = 3
-  zone_id = "${var.zone_id}"
+  zone_id = var.zone_id
   name    = "${element(aws_ses_domain_dkim.primary.dkim_tokens, count.index)}._domainkey.${var.domain}"
   type    = "CNAME"
   ttl     = "3600"
@@ -65,8 +65,8 @@ resource "aws_route53_record" "primary_amazonses_dkim_record" {
 }
 
 resource "aws_route53_record" "primary_amazonses_dmarc_record" {
-  count = "${length(var.dmarc) >= 1 ? 1 : 0}"
-  zone_id = "${var.zone_id}"
+  count   = length(var.dmarc) >= 1 ? 1 : 0
+  zone_id = var.zone_id
   name    = "_dmarc.${var.domain}"
   type    = "TXT"
   ttl     = "3600"
@@ -74,25 +74,25 @@ resource "aws_route53_record" "primary_amazonses_dmarc_record" {
 }
 
 resource "aws_route53_record" "primary_amazonses_mx_record" {
-  zone_id = "${var.zone_id}"
-  name    = "${aws_ses_domain_mail_from.primary.mail_from_domain}"
+  zone_id = var.zone_id
+  name    = aws_ses_domain_mail_from.primary.mail_from_domain
   type    = "MX"
   ttl     = "3600"
   records = ["10 feedback-smtp.${data.aws_region.mail_region.name}.amazonses.com"]
 }
 
 resource "aws_route53_record" "primary_amazonses_spf_record" {
-  zone_id = "${var.zone_id}"
-  name = "${aws_ses_domain_mail_from.primary.mail_from_domain}"
-  type = "TXT"
-  ttl = "3600"
+  zone_id = var.zone_id
+  name    = aws_ses_domain_mail_from.primary.mail_from_domain
+  type    = "TXT"
+  ttl     = "3600"
   records = ["v=spf1 include:amazonses.com -all"]
 }
 
 
 resource "aws_sns_topic" "delivery-events" {
-  provider = aws.email
-  name = "${var.name}-ses-delivery-events-topic"
+  provider     = aws.email
+  name         = "${var.name}-ses-delivery-events-topic"
   display_name = "${var.display_name} SES Delivery Events"
 
   delivery_policy = <<EOF
@@ -115,35 +115,35 @@ EOF
 
 
 resource "aws_sns_topic_subscription" "delivery-events" {
-    provider  = aws.email
-    topic_arn = "${aws_sns_topic.delivery-events.arn}"
-    protocol  = "https"
-    endpoint  = "${var.hook_url}"
-    endpoint_auto_confirms = true
+  provider               = aws.email
+  topic_arn              = aws_sns_topic.delivery-events.arn
+  protocol               = "https"
+  endpoint               = var.hook_url
+  endpoint_auto_confirms = true
 }
 
 
 resource "aws_ses_identity_notification_topic" "primary-deliveries" {
   provider          = aws.email
-  topic_arn         = "${aws_sns_topic.delivery-events.arn}"
+  topic_arn         = aws_sns_topic.delivery-events.arn
   notification_type = "Delivery"
-  identity          = "${aws_ses_domain_identity.primary.domain}"
+  identity          = aws_ses_domain_identity.primary.domain
 }
 
 
 resource "aws_ses_identity_notification_topic" "primary-bounces" {
   provider          = aws.email
-  topic_arn         = "${aws_sns_topic.delivery-events.arn}"
+  topic_arn         = aws_sns_topic.delivery-events.arn
   notification_type = "Bounce"
-  identity          = "${aws_ses_domain_identity.primary.domain}"
+  identity          = aws_ses_domain_identity.primary.domain
 }
 
 
 resource "aws_ses_identity_notification_topic" "primary-complaints" {
   provider          = aws.email
-  topic_arn         = "${aws_sns_topic.delivery-events.arn}"
+  topic_arn         = aws_sns_topic.delivery-events.arn
   notification_type = "Complaint"
-  identity          = "${aws_ses_domain_identity.primary.domain}"
+  identity          = aws_ses_domain_identity.primary.domain
 }
 
 
@@ -154,4 +154,4 @@ resource "aws_ses_identity_notification_topic" "primary-complaints" {
 #       SES domain to disable email notifications for bounces and complaints.
 
 
-output "delivery_topic" { value = "${aws_sns_topic.delivery-events.arn}" }
+output "delivery_topic" { value = aws_sns_topic.delivery-events.arn }

--- a/terraform/email/main.tf
+++ b/terraform/email/main.tf
@@ -124,26 +124,29 @@ resource "aws_sns_topic_subscription" "delivery-events" {
 
 
 resource "aws_ses_identity_notification_topic" "primary-deliveries" {
-  provider          = aws.email
-  topic_arn         = aws_sns_topic.delivery-events.arn
-  notification_type = "Delivery"
-  identity          = aws_ses_domain_identity.primary.domain
+  provider                 = aws.email
+  topic_arn                = aws_sns_topic.delivery-events.arn
+  notification_type        = "Delivery"
+  identity                 = aws_ses_domain_identity.primary.domain
+  include_original_headers = true
 }
 
 
 resource "aws_ses_identity_notification_topic" "primary-bounces" {
-  provider          = aws.email
-  topic_arn         = aws_sns_topic.delivery-events.arn
-  notification_type = "Bounce"
-  identity          = aws_ses_domain_identity.primary.domain
+  provider                 = aws.email
+  topic_arn                = aws_sns_topic.delivery-events.arn
+  notification_type        = "Bounce"
+  identity                 = aws_ses_domain_identity.primary.domain
+  include_original_headers = true
 }
 
 
 resource "aws_ses_identity_notification_topic" "primary-complaints" {
-  provider          = aws.email
-  topic_arn         = aws_sns_topic.delivery-events.arn
-  notification_type = "Complaint"
-  identity          = aws_ses_domain_identity.primary.domain
+  provider                 = aws.email
+  topic_arn                = aws_sns_topic.delivery-events.arn
+  notification_type        = "Complaint"
+  identity                 = aws_ses_domain_identity.primary.domain
+  include_original_headers = true
 }
 
 

--- a/terraform/file-hosting/main.tf
+++ b/terraform/file-hosting/main.tf
@@ -16,7 +16,8 @@ locals {
 }
 
 resource "fastly_service_vcl" "files_staging" {
-  name = "PyPI Staging File Hosting"
+  name     = "PyPI Staging File Hosting"
+  activate = false
 
   domain {
     name = var.staging_domain
@@ -179,7 +180,8 @@ resource "fastly_service_vcl" "files_staging" {
 }
 
 resource "fastly_service_vcl" "files" {
-  name = "PyPI File Hosting"
+  name     = "PyPI File Hosting"
+  activate = false
 
   domain {
     name = var.domain

--- a/terraform/file-hosting/main.tf
+++ b/terraform/file-hosting/main.tf
@@ -21,7 +21,8 @@ locals {
 
 resource "fastly_service_vcl" "files_staging" {
   name     = "PyPI Staging File Hosting"
-  activate = false
+  # Set to false for spicy changes
+  activate = true
 
   domain {
     name = var.staging_domain
@@ -207,7 +208,8 @@ resource "fastly_service_vcl" "files_staging" {
 
 resource "fastly_service_vcl" "files" {
   name     = "PyPI File Hosting"
-  activate = false
+  # Set to false for spicy changes
+  activate = true
 
   domain {
     name = var.domain

--- a/terraform/file-hosting/main.tf
+++ b/terraform/file-hosting/main.tf
@@ -45,7 +45,7 @@ resource "fastly_service_vcl" "files_staging" {
     content  = <<-EOT
         set var.AWS-Access-Key-ID = "${var.aws_access_key_id}";
         set var.AWS-Secret-Access-Key = "${var.aws_secret_access_key}";
-        set var.AWS-Bucket-Name = "${var.files_bucket}";
+        set var.S3-Bucket-Name = "${var.files_bucket}";
     EOT
   }
 
@@ -231,7 +231,7 @@ resource "fastly_service_vcl" "files" {
     content  = <<-EOT
         set var.AWS-Access-Key-ID = "${var.aws_access_key_id}";
         set var.AWS-Secret-Access-Key = "${var.aws_secret_access_key}";
-        set var.AWS-Bucket-Name = "${var.files_bucket}";
+        set var.S3-Bucket-Name = "${var.files_bucket}";
     EOT
   }
 

--- a/terraform/file-hosting/main.tf
+++ b/terraform/file-hosting/main.tf
@@ -381,7 +381,7 @@ resource "fastly_service_vcl" "files" {
   logging_s3 {
     name = "S3 Error Logs"
 
-    format         = "%%h \"%%{now}V\" %%l \"%%{req.request}V %%{req.url}V\" %%{req.proto}V %%>s %%{resp.http.Content-Length}V %%{resp.http.age}V \"%%{resp.http.x-cache}V\" \"%%{resp.http.x-cache-hits}V\" \"%%{req.http.content-type}V\" \"%%{req.http.accept-language}V\" \"%%{cstr_escape(req.http.user-agent)}V\" %%D \"%%{fastly_info.state}V\""
+    format         = "%h \"%%{now}V\" %l \"%%{req.request}V %%{req.url}V\" %%{req.proto}V %>s %%{resp.http.Content-Length}V %%{resp.http.age}V \"%%{resp.http.x-cache}V\" \"%%{resp.http.x-cache-hits}V\" \"%%{req.http.content-type}V\" \"%%{req.http.accept-language}V\" \"%%{cstr_escape(req.http.user-agent)}V\" %D \"%%{fastly_info.state}V\""
     format_version = 2
     gzip_level     = 9
 

--- a/terraform/file-hosting/main.tf
+++ b/terraform/file-hosting/main.tf
@@ -6,6 +6,10 @@ variable "files_bucket" { type = string }
 variable "mirror" { type = string }
 variable "linehaul_gcs" { type = map(any) }
 variable "s3_logging_keys" { type = map(any) }
+variable "aws_access_key_id" { type = string }
+variable "aws_secret_access_key" { type = string }
+variable "gcs_access_key_id" { type = string }
+variable "gcs_secret_access_key" { type = string }
 
 variable "fastly_endpoints" { type = map(any) }
 variable "domain_map" { type = map(any) }
@@ -21,6 +25,28 @@ resource "fastly_service_vcl" "files_staging" {
 
   domain {
     name = var.staging_domain
+  }
+
+  snippet {
+    name     = "GCS"
+    priority = 100
+    type     = "recv"
+    content  = <<-EOT
+        set var.GCS-Access-Key-ID = "${var.gcs_access_key_id}";
+        set var.GCS-Secret-Access-Key = "${var.gcs_secret_access_key}";
+        set var.GCS-Bucket-Name = "${var.files_bucket}";
+    EOT
+  }
+
+  snippet {
+    name     = "AWS"
+    priority = 100
+    type     = "recv"
+    content  = <<-EOT
+        set var.AWS-Access-Key-ID = "${var.aws_access_key_id}";
+        set var.AWS-Secret-Access-Key = "${var.aws_secret_access_key}";
+        set var.AWS-Bucket-Name = "${var.files_bucket}";
+    EOT
   }
 
   backend {
@@ -185,6 +211,28 @@ resource "fastly_service_vcl" "files" {
 
   domain {
     name = var.domain
+  }
+
+  snippet {
+    name     = "GCS"
+    priority = 100
+    type     = "recv"
+    content  = <<-EOT
+        set var.GCS-Access-Key-ID = "${var.gcs_access_key_id}";
+        set var.GCS-Secret-Access-Key = "${var.gcs_secret_access_key}";
+        set var.GCS-Bucket-Name = "${var.files_bucket}";
+    EOT
+  }
+
+  snippet {
+    name     = "AWS"
+    priority = 100
+    type     = "recv"
+    content  = <<-EOT
+        set var.AWS-Access-Key-ID = "${var.aws_access_key_id}";
+        set var.AWS-Secret-Access-Key = "${var.aws_secret_access_key}";
+        set var.AWS-Bucket-Name = "${var.files_bucket}";
+    EOT
   }
 
   backend {

--- a/terraform/file-hosting/main.tf
+++ b/terraform/file-hosting/main.tf
@@ -312,10 +312,10 @@ resource "fastly_service_vcl" "files" {
   logging_gcs {
     name             = "Linehaul GCS"
     bucket_name      = var.linehaul_gcs["bucket"]
-    path             = "downloads/%%Y/%%m/%%d/%%H/%%M/"
+    path             = "downloads/%Y/%m/%d/%H/%M/"
     message_type     = "blank"
     format           = "download|%%{now}V|%%{geoip.country_code}V|%%{req.url.path}V|%%{tls.client.protocol}V|%%{tls.client.cipher}V|%%{resp.http.x-amz-meta-project}V|%%{resp.http.x-amz-meta-version}V|%%{resp.http.x-amz-meta-package-type}V|%%{req.http.user-agent}V"
-    timestamp_format = "%%Y-%%m-%%dT%%H:%%M:%%S.000"
+    timestamp_format = "%Y-%m-%dT%H:%M:%S.000"
     gzip_level       = 9
     period           = 120
 
@@ -342,7 +342,7 @@ resource "fastly_service_vcl" "files" {
     s3_secret_key = var.s3_logging_keys["secret_key"]
     domain        = "s3-eu-west-1.amazonaws.com"
     bucket_name   = "psf-fastly-logs-eu-west-1"
-    path          = "/files-pythonhosted-org-errors/%%Y/%%m/%%d/%%H/%%M/"
+    path          = "/files-pythonhosted-org-errors/%Y/%m/%d/%H/%M/"
   }
 
 

--- a/terraform/file-hosting/versions.tf
+++ b/terraform/file-hosting/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    fastly = {
+      source = "fastly/fastly"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/terraform/gmail/main.tf
+++ b/terraform/gmail/main.tf
@@ -1,9 +1,17 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 0.13"
+}
 
-variable "domain" { type = "string" }
-variable "zone_id" { type = "string" }
+variable "domain" { type = string }
+variable "zone_id" { type = string }
 
-variable "dkim_host_name" { type = "string" }
-variable "dkim_txt_record" { type = "string" }
+variable "dkim_host_name" { type = string }
+variable "dkim_txt_record" { type = string }
 
 
 resource "aws_route53_record" "gmail_mx" {

--- a/terraform/gmail/main.tf
+++ b/terraform/gmail/main.tf
@@ -15,8 +15,8 @@ variable "dkim_txt_record" { type = string }
 
 
 resource "aws_route53_record" "gmail_mx" {
-  zone_id = "${var.zone_id}"
-  name    = "${var.domain}"
+  zone_id = var.zone_id
+  name    = var.domain
   type    = "MX"
   ttl     = "3600"
   records = [
@@ -30,7 +30,7 @@ resource "aws_route53_record" "gmail_mx" {
 
 
 resource "aws_route53_record" "primary_amazonses_dkim_record" {
-  zone_id = "${var.zone_id}"
+  zone_id = var.zone_id
   name    = "${var.dkim_host_name}.${var.domain}"
   type    = "TXT"
   ttl     = "3600"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,5 @@
 variable "linehaul_gcs_private_key" { type = string }
-variable "fastly_s3_logging" { type = map }
+variable "fastly_s3_logging" { type = map(any) }
 
 locals {
   tags = {
@@ -11,18 +11,18 @@ locals {
 
 locals {
   fastly_endpoints = {
-    "r.ssl.fastly.net_A"      = ["151.101.1.63", "151.101.65.63", "151.101.129.63", "151.101.193.63"]
-    "r.ssl.fastly.net_AAAA"   = ["2a04:4e42::319", "2a04:4e42:200::319", "2a04:4e42:400::319", "2a04:4e42:600::319"]
-    "r.ssl.fastly.net_CNAME"  = ["dualstack.r.ssl.global.fastly.net"]
+    "r.ssl.fastly.net_A"          = ["151.101.1.63", "151.101.65.63", "151.101.129.63", "151.101.193.63"]
+    "r.ssl.fastly.net_AAAA"       = ["2a04:4e42::319", "2a04:4e42:200::319", "2a04:4e42:400::319", "2a04:4e42:600::319"]
+    "r.ssl.fastly.net_CNAME"      = ["dualstack.r.ssl.global.fastly.net"]
     "python.map.fastly.net_A"     = ["151.101.128.223", "151.101.192.223", "151.101.0.223", "151.101.64.223"]
     "python.map.fastly.net_AAAA"  = ["2a04:4e42:200::223", "2a04:4e42:400::223", "2a04:4e42:600::223", "2a04:4e42::223"]
     "python.map.fastly.net_CNAME" = ["dualstack.python.map.fastly.net"]
   }
   domain_map = {
-    "pypi.org"                            = "python.map.fastly.net"
-    "pythonhosted.org"                    = "r.ssl.fastly.net"
-    "files.pythonhosted.org"              = "r.ssl.fastly.net"
-    "files-staging.pythonhosted.org"      = "r.ssl.fastly.net"
+    "pypi.org"                       = "python.map.fastly.net"
+    "pythonhosted.org"               = "r.ssl.fastly.net"
+    "files.pythonhosted.org"         = "r.ssl.fastly.net"
+    "files-staging.pythonhosted.org" = "r.ssl.fastly.net"
   }
 }
 
@@ -32,7 +32,7 @@ module "dns" {
 
   tags = local.tags
 
-  primary_domain = "pypi.org"
+  primary_domain      = "pypi.org"
   user_content_domain = "pythonhosted.org"
 
   caa_report_uri = "mailto:infrastructure-staff@python.org"
@@ -53,10 +53,10 @@ module "dns" {
 module "gmail" {
   source = "./gmail"
 
-  zone_id  = "${module.dns.primary_zone_id}"
-  domain = "pypi.org"
+  zone_id = module.dns.primary_zone_id
+  domain  = "pypi.org"
 
-  dkim_host_name = "google._domainkey"
+  dkim_host_name  = "google._domainkey"
   dkim_txt_record = "v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCS6JrwMkzjpDb1I6QbSxhiVeU9Fl2G1RJYtBR58Ult1+6pezNY9krZ8waNWcymaH8rvqlbKicPuwmzDSamC6lZhQZc05w5moDIF5lmu+Ji9jcQF679K1DP1nwy6B3ro4//62P0/88aFRRK+k+cth3ZQsSqNnxf9uQYykt75O7p/QIDAQAB"
 }
 
@@ -66,7 +66,7 @@ module "email" {
 
   name         = "pypi"
   display_name = "PyPI"
-  zone_id      = "${module.dns.primary_zone_id}"
+  zone_id      = module.dns.primary_zone_id
   domain       = "pypi.org"
   dmarc        = "mailto:re+ahhqsxbwmkl@dmarc.postmarkapp.com"
   hook_url     = "https://pypi.org/_/ses-hook/"
@@ -78,7 +78,7 @@ module "testpypi-email" {
 
   name         = "testpypi"
   display_name = "TestPyPI"
-  zone_id      = "${module.dns.primary_zone_id}"
+  zone_id      = module.dns.primary_zone_id
   domain       = "test.pypi.org"
   dmarc        = "mailto:re+qjfavuizyth@dmarc.postmarkapp.com"
   hook_url     = "https://test.pypi.org/_/ses-hook/"
@@ -88,9 +88,9 @@ module "testpypi-email" {
 module "pypi" {
   source = "./warehouse"
 
-  name            = "PyPI"
-  zone_id         = "${module.dns.primary_zone_id}"
-  domain          = "pypi.org"
+  name    = "PyPI"
+  zone_id = module.dns.primary_zone_id
+  domain  = "pypi.org"
   # Because of limitations of the Terraform fastly provider, there must be the same
   # number of entries in any extra_domains across instances of this module, and
   # changing the number of elements in the list requires modifying the module to
@@ -98,7 +98,7 @@ module "pypi" {
   extra_domains   = ["www.pypi.org", "pypi.python.org", "pypi.io", "www.pypi.io", "warehouse.python.org"]
   backend         = "warehouse.cmh1.psfhosted.org"
   mirror          = "mirror.dub1.pypi.io"
-  s3_logging_keys = "${var.fastly_s3_logging}"
+  s3_logging_keys = var.fastly_s3_logging
 
   linehaul_gcs = {
     bucket      = "linehaul-logs"
@@ -106,21 +106,21 @@ module "pypi" {
     private_key = "${var.linehaul_gcs_private_key}"
   }
 
-  fastly_endpoints = "${local.fastly_endpoints}"
-  domain_map       = "${local.domain_map}"
+  fastly_endpoints = local.fastly_endpoints
+  domain_map       = local.domain_map
 }
 
 
 module "file-hosting" {
   source = "./file-hosting"
 
-  zone_id          = "${module.dns.user_content_zone_id}"
+  zone_id          = module.dns.user_content_zone_id
   domain           = "files.pythonhosted.org"
   staging_domain   = "files-staging.pythonhosted.org"
   conveyor_address = "conveyor.cmh1.psfhosted.org"
   files_bucket     = "pypi-files"
   mirror           = "mirror.dub1.pypi.io"
-  s3_logging_keys = "${var.fastly_s3_logging}"
+  s3_logging_keys  = var.fastly_s3_logging
 
   linehaul_gcs = {
     bucket      = "linehaul-logs"
@@ -128,23 +128,23 @@ module "file-hosting" {
     private_key = "${var.linehaul_gcs_private_key}"
   }
 
-  fastly_endpoints = "${local.fastly_endpoints}"
-  domain_map       = "${local.domain_map}"
+  fastly_endpoints = local.fastly_endpoints
+  domain_map       = local.domain_map
 }
 
 
 module "docs-hosting" {
   source = "./docs-hosting"
 
-  zone_id          = "${module.dns.user_content_zone_id}"
+  zone_id          = module.dns.user_content_zone_id
   domain           = "pythonhosted.org"
   conveyor_address = "conveyor.cmh1.psfhosted.org"
 
-  fastly_endpoints = "${local.fastly_endpoints}"
-  domain_map       = "${local.domain_map}"
+  fastly_endpoints = local.fastly_endpoints
+  domain_map       = local.domain_map
 }
 
 
 output "nameservers" { value = ["${module.dns.nameservers}"] }
-output "pypi-ses_delivery_topic" { value = "${module.email.delivery_topic}" }
-output "testpypi-ses_delivery_topic" { value = "${module.testpypi-email.delivery_topic}" }
+output "pypi-ses_delivery_topic" { value = module.email.delivery_topic }
+output "testpypi-ses_delivery_topic" { value = module.testpypi-email.delivery_topic }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -152,6 +152,6 @@ module "docs-hosting" {
 }
 
 
-output "nameservers" { value = ["${module.dns.nameservers}"] }
+output "nameservers" { value = module.dns.nameservers }
 output "pypi-ses_delivery_topic" { value = module.email.delivery_topic }
 output "testpypi-ses_delivery_topic" { value = module.testpypi-email.delivery_topic }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -100,6 +100,8 @@ module "pypi" {
   mirror          = "mirror.dub1.pypi.io"
   s3_logging_keys = var.fastly_s3_logging
 
+  warehouse_token = var.warehouse_token
+
   linehaul_gcs = {
     bucket      = "linehaul-logs"
     email       = "linehaul-logs@the-psf.iam.gserviceaccount.com"
@@ -121,6 +123,11 @@ module "file-hosting" {
   files_bucket     = "pypi-files"
   mirror           = "mirror.dub1.pypi.io"
   s3_logging_keys  = var.fastly_s3_logging
+
+  aws_access_key_id     = var.aws_access_key_id
+  aws_secret_access_key = var.aws_secret_access_key
+  gcs_access_key_id     = var.gcs_access_key_id
+  gcs_secret_access_key = var.gcs_secret_access_key
 
   linehaul_gcs = {
     bucket      = "linehaul-logs"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,5 @@
-variable "linehaul_gcs_private_key" { type = "string" }
-variable "fastly_s3_logging" { type = "map" }
+variable "linehaul_gcs_private_key" { type = string }
+variable "fastly_s3_logging" { type = map }
 
 locals {
   tags = {
@@ -10,19 +10,19 @@ locals {
 
 
 locals {
-  fastly_endpoints {
-    r.ssl.fastly.net_A      = ["151.101.1.63", "151.101.65.63", "151.101.129.63", "151.101.193.63"]
-    r.ssl.fastly.net_AAAA   = ["2a04:4e42::319", "2a04:4e42:200::319", "2a04:4e42:400::319", "2a04:4e42:600::319"]
-    r.ssl.fastly.net_CNAME  = ["dualstack.r.ssl.global.fastly.net"]
-    python.map.fastly.net_A     = ["151.101.128.223", "151.101.192.223", "151.101.0.223", "151.101.64.223"]
-    python.map.fastly.net_AAAA  = ["2a04:4e42:200::223", "2a04:4e42:400::223", "2a04:4e42:600::223", "2a04:4e42::223"]
-    python.map.fastly.net_CNAME = ["dualstack.python.map.fastly.net"]
+  fastly_endpoints = {
+    "r.ssl.fastly.net_A"      = ["151.101.1.63", "151.101.65.63", "151.101.129.63", "151.101.193.63"]
+    "r.ssl.fastly.net_AAAA"   = ["2a04:4e42::319", "2a04:4e42:200::319", "2a04:4e42:400::319", "2a04:4e42:600::319"]
+    "r.ssl.fastly.net_CNAME"  = ["dualstack.r.ssl.global.fastly.net"]
+    "python.map.fastly.net_A"     = ["151.101.128.223", "151.101.192.223", "151.101.0.223", "151.101.64.223"]
+    "python.map.fastly.net_AAAA"  = ["2a04:4e42:200::223", "2a04:4e42:400::223", "2a04:4e42:600::223", "2a04:4e42::223"]
+    "python.map.fastly.net_CNAME" = ["dualstack.python.map.fastly.net"]
   }
-  domain_map {
-    pypi.org                            = "python.map.fastly.net"
-    pythonhosted.org                    = "r.ssl.fastly.net"
-    files.pythonhosted.org              = "r.ssl.fastly.net"
-    files-staging.pythonhosted.org      = "r.ssl.fastly.net"
+  domain_map = {
+    "pypi.org"                            = "python.map.fastly.net"
+    "pythonhosted.org"                    = "r.ssl.fastly.net"
+    "files.pythonhosted.org"              = "r.ssl.fastly.net"
+    "files-staging.pythonhosted.org"      = "r.ssl.fastly.net"
   }
 }
 
@@ -30,7 +30,7 @@ locals {
 module "dns" {
   source = "./dns"
 
-  tags = "${local.tags}"
+  tags = local.tags
 
   primary_domain = "pypi.org"
   user_content_domain = "pythonhosted.org"
@@ -63,10 +63,6 @@ module "gmail" {
 
 module "email" {
   source = "./email"
-  providers = {
-    "aws" = "aws"
-    "aws.email" = "aws.us-west-2"
-  }
 
   name         = "pypi"
   display_name = "PyPI"
@@ -79,10 +75,6 @@ module "email" {
 
 module "testpypi-email" {
   source = "./email"
-  providers = {
-    "aws" = "aws"
-    "aws.email" = "aws.us-west-2"
-  }
 
   name         = "testpypi"
   display_name = "TestPyPI"

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "4.9.0"
+    }
+    fastly = {
+      source  = "fastly/fastly"
+      version = "1.1.2"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -9,5 +9,5 @@ terraform {
       version = "1.1.2"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.1.8"
 }

--- a/terraform/warehouse/main.tf
+++ b/terraform/warehouse/main.tf
@@ -113,7 +113,7 @@ resource "fastly_service_vcl" "pypi" {
   logging_s3 {
     name = "S3 Logs"
 
-    format         = "%%h \"%%{now}V\" %%l \"%%{req.request}V %%{req.url}V\" %%{req.proto}V %%>s %%{resp.http.Content-Length}V %%{resp.http.age}V \"%%{resp.http.x-cache}V\" \"%%{resp.http.x-cache-hits}V\" \"%%{req.http.content-type}V\" \"%%{req.http.accept-language}V\" \"%%{cstr_escape(req.http.user-agent)}V\""
+    format         = "%h \"%%{now}V\" %l \"%%{req.request}V %%{req.url}V\" %%{req.proto}V %>s %%{resp.http.Content-Length}V %%{resp.http.age}V \"%%{resp.http.x-cache}V\" \"%%{resp.http.x-cache-hits}V\" \"%%{req.http.content-type}V\" \"%%{req.http.accept-language}V\" \"%%{cstr_escape(req.http.user-agent)}V\""
     format_version = 2
     gzip_level     = 9
 
@@ -127,7 +127,7 @@ resource "fastly_service_vcl" "pypi" {
   logging_s3 {
     name = "S3 Error Logs"
 
-    format         = "%h \"%%{now}V\" %l \"%%{req.request}V %%{req.url}V\" %%{req.proto}V %%>s %%{resp.http.Content-Length}V %%{resp.http.age}V \"%%{resp.http.x-cache}V\" \"%%{resp.http.x-cache-hits}V\" \"%%{req.http.content-type}V\" \"%%{req.http.accept-language}V\" \"%%{cstr_escape(req.http.user-agent)}V\" %%D \"%%{fastly_info.state}V\" \"%%{req.restarts}V\" \"%%{req.backend}V\""
+    format         = "%h \"%%{now}V\" %l \"%%{req.request}V %%{req.url}V\" %%{req.proto}V %>s %%{resp.http.Content-Length}V %%{resp.http.age}V \"%%{resp.http.x-cache}V\" \"%%{resp.http.x-cache-hits}V\" \"%%{req.http.content-type}V\" \"%%{req.http.accept-language}V\" \"%%{cstr_escape(req.http.user-agent)}V\" %D \"%%{fastly_info.state}V\" \"%%{req.restarts}V\" \"%%{req.backend}V\""
     format_version = 2
     gzip_level     = 9
 

--- a/terraform/warehouse/main.tf
+++ b/terraform/warehouse/main.tf
@@ -29,8 +29,9 @@ resource "fastly_service_vcl" "pypi" {
   domain { name = var.extra_domains[4] }
 
   backend {
-    name   = "Application"
-    shield = "iad-va-us"
+    name             = "Application"
+    shield           = "iad-va-us"
+    auto_loadbalance = true
 
     healthcheck = "Application Health"
 
@@ -111,7 +112,7 @@ resource "fastly_service_vcl" "pypi" {
     s3_secret_key = var.s3_logging_keys["secret_key"]
     domain        = "s3-eu-west-1.amazonaws.com"
     bucket_name   = "psf-fastly-logs-eu-west-1"
-    path          = "/pypi-org/%%Y/%%m/%%d/"
+    path          = "/pypi-org/%Y/%m/%d/"
   }
 
   logging_s3 {
@@ -128,16 +129,16 @@ resource "fastly_service_vcl" "pypi" {
     s3_secret_key = var.s3_logging_keys["secret_key"]
     domain        = "s3-eu-west-1.amazonaws.com"
     bucket_name   = "psf-fastly-logs-eu-west-1"
-    path          = "/pypi-org-errors/%%Y/%%m/%%d/%%H/%%M/"
+    path          = "/pypi-org-errors/%Y/%m/%d/%H/%M/"
   }
 
   logging_gcs {
     name             = "Linehaul GCS"
     bucket_name      = var.linehaul_gcs["bucket"]
-    path             = "simple/%%Y/%%m/%%d/%%H/%%M/"
+    path             = "simple/%Y/%m/%d/%H/%M/"
     message_type     = "blank"
     format           = "simple|%%{now}V|%%{geoip.country_code}V|%%{req.url.path}V|%%{tls.client.protocol}V|%%{tls.client.cipher}V||||%%{req.http.user-agent}V"
-    timestamp_format = "%%Y-%%m-%%dT%%H:%%M:%%S.000"
+    timestamp_format = "%Y-%m-%dT%H:%M:%S.000"
     gzip_level       = 9
     period           = 120
 

--- a/terraform/warehouse/main.tf
+++ b/terraform/warehouse/main.tf
@@ -19,7 +19,8 @@ locals {
 
 resource "fastly_service_vcl" "pypi" {
   name     = "PyPI"
-  activate = false
+  # Set to false for spicy changes
+  activate = true
 
   domain { name = var.domain }
 

--- a/terraform/warehouse/main.tf
+++ b/terraform/warehouse/main.tf
@@ -1,44 +1,44 @@
 variable "name" { type = string }
 variable "zone_id" { type = string }
 variable "domain" { type = string }
-variable "extra_domains" { type = list }
+variable "extra_domains" { type = list(any) }
 variable "backend" { type = string }
 variable "mirror" { type = string }
-variable "s3_logging_keys" { type = map }
-variable "linehaul_gcs" { type = map }
+variable "s3_logging_keys" { type = map(any) }
+variable "linehaul_gcs" { type = map(any) }
 
-variable "fastly_endpoints" { type = map }
-variable "domain_map" { type = map }
+variable "fastly_endpoints" { type = map(any) }
+variable "domain_map" { type = map(any) }
 
 
 locals {
-  apex_domain = "${length(split(".", var.domain)) > 2 ? false : true}"
+  apex_domain = length(split(".", var.domain)) > 2 ? false : true
 }
 
 
 resource "fastly_service_vcl" "pypi" {
   name = "PyPI"
 
-  domain { name = "${var.domain}" }
+  domain { name = var.domain }
 
   # Extra Domains
-  domain { name = "${var.extra_domains[0]}" }
-  domain { name = "${var.extra_domains[1]}" }
-  domain { name = "${var.extra_domains[2]}" }
-  domain { name = "${var.extra_domains[3]}" }
-  domain { name = "${var.extra_domains[4]}" }
+  domain { name = var.extra_domains[0] }
+  domain { name = var.extra_domains[1] }
+  domain { name = var.extra_domains[2] }
+  domain { name = var.extra_domains[3] }
+  domain { name = var.extra_domains[4] }
 
   backend {
-    name             = "Application"
-    shield           = "iad-va-us"
+    name   = "Application"
+    shield = "iad-va-us"
 
-    healthcheck      = "Application Health"
+    healthcheck = "Application Health"
 
-    address           = "${var.backend}"
+    address           = var.backend
     port              = 443
     use_ssl           = true
-    ssl_cert_hostname = "${var.backend}"
-    ssl_sni_hostname  = "${var.backend}"
+    ssl_cert_hostname = var.backend
+    ssl_sni_hostname  = var.backend
 
     connect_timeout       = 5000
     first_byte_timeout    = 60000
@@ -47,18 +47,18 @@ resource "fastly_service_vcl" "pypi" {
   }
 
   backend {
-    name              = "Mirror"
-    auto_loadbalance  = false
-    shield            = "london_city-uk"
+    name             = "Mirror"
+    auto_loadbalance = false
+    shield           = "london_city-uk"
 
     request_condition = "Primary Failure (Mirror-able)"
     healthcheck       = "Mirror Health"
 
-    address           = "${var.mirror}"
+    address           = var.mirror
     port              = 443
     use_ssl           = true
-    ssl_cert_hostname = "${var.mirror}"
-    ssl_sni_hostname  = "${var.mirror}"
+    ssl_cert_hostname = var.mirror
+    ssl_sni_hostname  = var.mirror
 
     connect_timeout       = 5000
     first_byte_timeout    = 60000
@@ -67,73 +67,73 @@ resource "fastly_service_vcl" "pypi" {
   }
 
   healthcheck {
-    name   = "Application Health"
+    name = "Application Health"
 
-    host   = "${var.domain}"
+    host   = var.domain
     method = "GET"
     path   = "/_health/"
 
     check_interval = 6000
-    timeout = 4000
-    threshold = 2
-    initial = 2
-    window = 4
+    timeout        = 4000
+    threshold      = 2
+    initial        = 2
+    window         = 4
   }
 
   healthcheck {
-    name   = "Mirror Health"
+    name = "Mirror Health"
 
-    host   = "${var.domain}"
+    host   = var.domain
     method = "GET"
     path   = "/last-modified"
 
     check_interval = 3000
-    timeout = 2000
-    threshold = 2
-    initial = 2
-    window = 4
+    timeout        = 2000
+    threshold      = 2
+    initial        = 2
+    window         = 4
   }
 
   vcl {
     name    = "Main"
-    content = templatefile("${path.module}/vcl/main.vcl", {pretty_503 = file("${path.module}/html/error.html")})
+    content = templatefile("${path.module}/vcl/main.vcl", { pretty_503 = file("${path.module}/html/error.html") })
     main    = true
   }
 
   logging_s3 {
-    name           = "S3 Logs"
+    name = "S3 Logs"
 
     format         = "%%h \"%%{now}V\" %%l \"%%{req.request}V %%{req.url}V\" %%{req.proto}V %%>s %%{resp.http.Content-Length}V %%{resp.http.age}V \"%%{resp.http.x-cache}V\" \"%%{resp.http.x-cache-hits}V\" \"%%{req.http.content-type}V\" \"%%{req.http.accept-language}V\" \"%%{cstr_escape(req.http.user-agent)}V\""
     format_version = 2
     gzip_level     = 9
 
-    s3_access_key  = "${var.s3_logging_keys["access_key"]}"
-    s3_secret_key  = "${var.s3_logging_keys["secret_key"]}"
-    domain         = "s3-eu-west-1.amazonaws.com"
-    bucket_name    = "psf-fastly-logs-eu-west-1"
-    path           = "/pypi-org/%%Y/%%m/%%d/"
+    s3_access_key = var.s3_logging_keys["access_key"]
+    s3_secret_key = var.s3_logging_keys["secret_key"]
+    domain        = "s3-eu-west-1.amazonaws.com"
+    bucket_name   = "psf-fastly-logs-eu-west-1"
+    path          = "/pypi-org/%%Y/%%m/%%d/"
   }
 
   logging_s3 {
-    name           = "S3 Error Logs"
+    name = "S3 Error Logs"
 
     format         = "%h \"%%{now}V\" %l \"%%{req.request}V %%{req.url}V\" %%{req.proto}V %%>s %%{resp.http.Content-Length}V %%{resp.http.age}V \"%%{resp.http.x-cache}V\" \"%%{resp.http.x-cache-hits}V\" \"%%{req.http.content-type}V\" \"%%{req.http.accept-language}V\" \"%%{cstr_escape(req.http.user-agent)}V\" %%D \"%%{fastly_info.state}V\" \"%%{req.restarts}V\" \"%%{req.backend}V\""
     format_version = 2
     gzip_level     = 9
 
-    period         = 60
+    period             = 60
     response_condition = "5xx Error"
 
-    s3_access_key  = "${var.s3_logging_keys["access_key"]}"
-    s3_secret_key  = "${var.s3_logging_keys["secret_key"]}"
-    domain         = "s3-eu-west-1.amazonaws.com"
-    bucket_name    = "psf-fastly-logs-eu-west-1"
-    path           = "/pypi-org-errors/%%Y/%%m/%%d/%%H/%%M/"
+    s3_access_key = var.s3_logging_keys["access_key"]
+    s3_secret_key = var.s3_logging_keys["secret_key"]
+    domain        = "s3-eu-west-1.amazonaws.com"
+    bucket_name   = "psf-fastly-logs-eu-west-1"
+    path          = "/pypi-org-errors/%%Y/%%m/%%d/%%H/%%M/"
   }
 
   logging_gcs {
     name             = "Linehaul GCS"
-    bucket_name      = "${var.linehaul_gcs["bucket"]}"
+    bucket_name      = var.linehaul_gcs["bucket"]
     path             = "simple/%%Y/%%m/%%d/%%H/%%M/"
     message_type     = "blank"
     format           = "simple|%%{now}V|%%{geoip.country_code}V|%%{req.url.path}V|%%{tls.client.protocol}V|%%{tls.client.cipher}V||||%%{req.http.user-agent}V"
@@ -141,17 +141,17 @@ resource "fastly_service_vcl" "pypi" {
     gzip_level       = 9
     period           = 120
 
-    user             = "${var.linehaul_gcs["email"]}"
-    secret_key       = "${var.linehaul_gcs["private_key"]}"
+    user       = var.linehaul_gcs["email"]
+    secret_key = var.linehaul_gcs["private_key"]
 
     response_condition = "Linehaul Log"
   }
 
   response_object {
-    name = "Bandersnatch User-Agent prohibited"
-    status = 403
-    content = "Bandersnatch version no longer supported, upgrade to 1.4+"
-    content_type = "text/plain"
+    name              = "Bandersnatch User-Agent prohibited"
+    status            = 403
+    content           = "Bandersnatch version no longer supported, upgrade to 1.4+"
+    content_type      = "text/plain"
     request_condition = "Bandersnatch User-Agent prohibited"
   }
 
@@ -163,20 +163,20 @@ resource "fastly_service_vcl" "pypi" {
   }
 
   condition {
-    name = "5xx Error"
-    type = "RESPONSE"
+    name      = "5xx Error"
+    type      = "RESPONSE"
     statement = "(resp.status >= 500 && resp.status < 600)"
   }
 
   condition {
-    name = "Bandersnatch User-Agent prohibited"
-    type = "REQUEST"
+    name      = "Bandersnatch User-Agent prohibited"
+    type      = "REQUEST"
     statement = "req.http.user-agent ~ \"bandersnatch/1\\.(0|1|2|3)\\ \""
   }
 
   condition {
-    name = "Linehaul Log"
-    type = "RESPONSE"
+    name      = "Linehaul Log"
+    type      = "RESPONSE"
     statement = "!req.http.Fastly-FF && req.url.path ~ \"^/simple/.+/\" && req.request == \"GET\" && http_status_matches(resp.status, \"200,304\")"
   }
 
@@ -189,18 +189,18 @@ resource "fastly_service_vcl" "pypi" {
 
 
 resource "aws_route53_record" "primary" {
-  zone_id = "${var.zone_id}"
-  name    = "${var.domain}"
-  type    = "${local.apex_domain ? "A" : "CNAME"}"
+  zone_id = var.zone_id
+  name    = var.domain
+  type    = local.apex_domain ? "A" : "CNAME"
   ttl     = 86400
   records = var.fastly_endpoints[join("_", concat([var.domain_map[var.domain]], [local.apex_domain ? "A" : "CNAME"]))]
 }
 
 
 resource "aws_route53_record" "primary-ipv6" {
-  count   = "${local.apex_domain ? 1 : 0}"
-  zone_id = "${var.zone_id}"
-  name    = "${var.domain}"
+  count   = local.apex_domain ? 1 : 0
+  zone_id = var.zone_id
+  name    = var.domain
   type    = "AAAA"
   ttl     = 86400
   records = var.fastly_endpoints[join("_", [var.domain_map[var.domain], "AAAA"])]

--- a/terraform/warehouse/main.tf
+++ b/terraform/warehouse/main.tf
@@ -17,7 +17,8 @@ locals {
 
 
 resource "fastly_service_vcl" "pypi" {
-  name = "PyPI"
+  name     = "PyPI"
+  activate = false
 
   domain { name = var.domain }
 

--- a/terraform/warehouse/main.tf
+++ b/terraform/warehouse/main.tf
@@ -6,6 +6,7 @@ variable "backend" { type = string }
 variable "mirror" { type = string }
 variable "s3_logging_keys" { type = map(any) }
 variable "linehaul_gcs" { type = map(any) }
+variable "warehouse_token" { type = string }
 
 variable "fastly_endpoints" { type = map(any) }
 variable "domain_map" { type = map(any) }
@@ -28,6 +29,13 @@ resource "fastly_service_vcl" "pypi" {
   domain { name = var.extra_domains[2] }
   domain { name = var.extra_domains[3] }
   domain { name = var.extra_domains[4] }
+
+  snippet {
+    content  = "set req.http.Warehouse-Token = \"${var.warehouse_token}\";"
+    name     = "Warehouse Token"
+    priority = 100
+    type     = "recv"
+  }
 
   backend {
     name             = "Application"

--- a/terraform/warehouse/versions.tf
+++ b/terraform/warehouse/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    fastly = {
+      source = "fastly/fastly"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/terraform/warehouse/worker.tf
+++ b/terraform/warehouse/worker.tf
@@ -1,5 +1,5 @@
 resource "aws_sqs_queue" "pypi_worker" {
-  name                       = "${lower(var.name)}-worker"
+  name = "${lower(var.name)}-worker"
   # We're going to set this to 15 minutes, which basically means that if a worker
   # hasn't completed the task within 15 minutes, then SQS will make it visible for
   # another work to accept it.
@@ -7,7 +7,7 @@ resource "aws_sqs_queue" "pypi_worker" {
 }
 
 resource "aws_sqs_queue" "pypi_worker_default" {
-  name                       = "${lower(var.name)}-worker-default"
+  name = "${lower(var.name)}-worker-default"
   # We're going to set this to 15 minutes, which basically means that if a worker
   # hasn't completed the task within 15 minutes, then SQS will make it visible for
   # another work to accept it.
@@ -15,7 +15,7 @@ resource "aws_sqs_queue" "pypi_worker_default" {
 }
 
 resource "aws_sqs_queue" "pypi_worker_malware" {
-  name                       = "${lower(var.name)}-worker-malware"
+  name = "${lower(var.name)}-worker-malware"
   # We're going to set this to 15 minutes, which basically means that if a worker
   # hasn't completed the task within 15 minutes, then SQS will make it visible for
   # another work to accept it.
@@ -26,7 +26,7 @@ resource "aws_iam_policy" "pypi_worker" {
   name        = "${var.name}WorkerSQS"
   description = "R/W Access to PyPI's SQS Worker Queue"
 
-  policy      = <<EOF
+  policy = <<EOF
 {
   "Version": "2012-10-17",
   "Statement": [


### PR DESCRIPTION
```
Plan: 0 to add, 4 to change, 0 to destroy.
```

Changes:

```
Terraform will perform the following actions:

  # module.docs-hosting.fastly_service_vcl.docs will be updated in-place
  ~ resource "fastly_service_vcl" "docs" {
      + activate           = false
      ~ cloned_version     = 8 -> (known after apply)
        id                 = "6RdgH2FOXbKFjczNLQCnxY"
        name               = "PyPI Docs Hosting"
        # (5 unchanged attributes hidden)




        # (4 unchanged blocks hidden)
    }

  # module.file-hosting.fastly_service_vcl.files will be updated in-place
  ~ resource "fastly_service_vcl" "files" {
      + activate           = false
      ~ cloned_version     = 98 -> (known after apply)
      + default_host       = ""
        id                 = "62OyyXk6MTgn4a4JO0NbIO"
        name               = "PyPI File Hosting"
      + version_comment    = ""
        # (5 unchanged attributes hidden)






      + logging_s3 {
          + bucket_name        = "psf-fastly-logs-eu-west-1"
          + domain             = "s3-eu-west-1.amazonaws.com"
          + format             = "%%h \"%{now}V\" %%l \"%{req.request}V %{req.url}V\" %{req.proto}V %%>s %{resp.http.Content-Length}V %{resp.http.age}V \"%{resp.http.x-cache}V\" \"%{resp.http.x-cache-hits}V\" \"%{req.http.content-type}V\" \"%{req.http.accept-language}V\" \"%{cstr_escape(req.http.user-agent)}V\" %%D \"%{fastly_info.state}V\""
          + format_version     = 2
          + gzip_level         = 9
          + message_type       = "classic"
          + name               = "S3 Error Logs"
          + path               = "/files-pythonhosted-org-errors/%Y/%m/%d/%H/%M/"
          + period             = 60
          + response_condition = "5xx Error"
          + s3_access_key      = (sensitive value)
          + s3_secret_key      = (sensitive value)
          + timestamp_format   = "%Y-%m-%dT%H:%M:%S.000"
        }
      - logging_s3 {
          - bucket_name        = "psf-fastly-logs-eu-west-1" -> null
          - domain             = "s3-eu-west-1.amazonaws.com" -> null
          - format             = "%h \"%{now}V\" %l \"%{req.request}V %{req.url}V\" %{req.proto}V %>s %{resp.http.Content-Length}V %{resp.http.age}V \"%{resp.http.x-cache}V\" \"%{resp.http.x-cache-hits}V\" \"%{req.http.content-type}V\" \"%{req.http.accept-language}V\" \"%{cstr_escape(req.http.user-agent)}V\" %D \"%{fastly_info.state}V\"" -> null
          - format_version     = 2 -> null
          - gzip_level         = 9 -> null
          - message_type       = "classic" -> null
          - name               = "S3 Error Logs" -> null
          - path               = "/files-pythonhosted-org-errors/%Y/%m/%d/%H/%M/" -> null
          - period             = 60 -> null
          - response_condition = "5xx Error" -> null
          - s3_access_key      = (sensitive value)
          - s3_secret_key      = (sensitive value)
          - timestamp_format   = "%Y-%m-%dT%H:%M:%S.000" -> null
        }

      # Warning: this block will be marked as sensitive and will not
      # display in UI output after applying this change.
      ~ snippet {
          # At least one attribute in this block is (or was) sensitive,
          # so its contents will not be displayed.
        }

        # (15 unchanged blocks hidden)
    }

  # module.file-hosting.fastly_service_vcl.files_staging will be updated in-place
  ~ resource "fastly_service_vcl" "files_staging" {
      + activate           = false
      ~ cloned_version     = 28 -> (known after apply)
      + default_host       = ""
        id                 = "2Cgi9YlJnjsGNbhDLfOPvA"
        name               = "PyPI Staging File Hosting"
      + version_comment    = ""
        # (5 unchanged attributes hidden)





      # Warning: this block will be marked as sensitive and will not
      # display in UI output after applying this change.
      ~ snippet {
          # At least one attribute in this block is (or was) sensitive,
          # so its contents will not be displayed.
        }

        # (14 unchanged blocks hidden)
    }

  # module.pypi.aws_route53_record.primary-ipv6 has moved to module.pypi.aws_route53_record.primary-ipv6[0]
    resource "aws_route53_record" "primary-ipv6" {
        id              = "Z2BIT24T5LM0F3_pypi.org_AAAA"
        name            = "pypi.org"
        # (6 unchanged attributes hidden)
    }

  # module.pypi.fastly_service_vcl.pypi will be updated in-place
  ~ resource "fastly_service_vcl" "pypi" {
      + activate           = false
      ~ cloned_version     = 128 -> (known after apply)
      + default_host       = ""
        id                 = "2M2szYhuuDVGuIS6NlWe5G"
        name               = "PyPI"
      + version_comment    = ""
        # (5 unchanged attributes hidden)






      + logging_s3 {
          + bucket_name      = "psf-fastly-logs-eu-west-1"
          + domain           = "s3-eu-west-1.amazonaws.com"
          + format           = "%%h \"%{now}V\" %%l \"%{req.request}V %{req.url}V\" %{req.proto}V %%>s %{resp.http.Content-Length}V %{resp.http.age}V \"%{resp.http.x-cache}V\" \"%{resp.http.x-cache-hits}V\" \"%{req.http.content-type}V\" \"%{req.http.accept-language}V\" \"%{cstr_escape(req.http.user-agent)}V\""
          + format_version   = 2
          + gzip_level       = 9
          + message_type     = "classic"
          + name             = "S3 Logs"
          + path             = "/pypi-org/%Y/%m/%d/"
          + period           = 3600
          + s3_access_key    = (sensitive value)
          + s3_secret_key    = (sensitive value)
          + timestamp_format = "%Y-%m-%dT%H:%M:%S.000"
        }
      + logging_s3 {
          + bucket_name        = "psf-fastly-logs-eu-west-1"
          + domain             = "s3-eu-west-1.amazonaws.com"
          + format             = "%h \"%{now}V\" %l \"%{req.request}V %{req.url}V\" %{req.proto}V %%>s %{resp.http.Content-Length}V %{resp.http.age}V \"%{resp.http.x-cache}V\" \"%{resp.http.x-cache-hits}V\" \"%{req.http.content-type}V\" \"%{req.http.accept-language}V\" \"%{cstr_escape(req.http.user-agent)}V\" %%D \"%{fastly_info.state}V\" \"%{req.restarts}V\" \"%{req.backend}V\""
          + format_version     = 2
          + gzip_level         = 9
          + message_type       = "classic"
          + name               = "S3 Error Logs"
          + path               = "/pypi-org-errors/%Y/%m/%d/%H/%M/"
          + period             = 60
          + response_condition = "5xx Error"
          + s3_access_key      = (sensitive value)
          + s3_secret_key      = (sensitive value)
          + timestamp_format   = "%Y-%m-%dT%H:%M:%S.000"
        }
      - logging_s3 {
          - bucket_name        = "psf-fastly-logs-eu-west-1" -> null
          - domain             = "s3-eu-west-1.amazonaws.com" -> null
          - format             = "%h \"%{now}V\" %l \"%{req.request}V %{req.url}V\" %{req.proto}V %>s %{resp.http.Content-Length}V %{resp.http.age}V \"%{resp.http.x-cache}V\" \"%{resp.http.x-cache-hits}V\" \"%{req.http.content-type}V\" \"%{req.http.accept-language}V\" \"%{cstr_escape(req.http.user-agent)}V\" %D \"%{fastly_info.state}V\" \"%{req.restarts}V\" \"%{req.backend}V\"" -> null
          - format_version     = 2 -> null
          - gzip_level         = 9 -> null
          - message_type       = "classic" -> null
          - name               = "S3 Error Logs" -> null
          - path               = "/pypi-org-errors/%Y/%m/%d/%H/%M/" -> null
          - period             = 60 -> null
          - response_condition = "5xx Error" -> null
          - s3_access_key      = (sensitive value)
          - s3_secret_key      = (sensitive value)
          - timestamp_format   = "%Y-%m-%dT%H:%M:%S.000" -> null
        }
      - logging_s3 {
          - bucket_name      = "psf-fastly-logs-eu-west-1" -> null
          - domain           = "s3-eu-west-1.amazonaws.com" -> null
          - format           = "%h \"%{now}V\" %l \"%{req.request}V %{req.url}V\" %{req.proto}V %>s %{resp.http.Content-Length}V %{resp.http.age}V \"%{resp.http.x-cache}V\" \"%{resp.http.x-cache-hits}V\" \"%{req.http.content-type}V\" \"%{req.http.accept-language}V\" \"%{cstr_escape(req.http.user-agent)}V\"" -> null
          - format_version   = 2 -> null
          - gzip_level       = 9 -> null
          - message_type     = "classic" -> null
          - name             = "S3 Logs" -> null
          - path             = "/pypi-org/%Y/%m/%d/" -> null
          - period           = 3600 -> null
          - s3_access_key    = (sensitive value)
          - s3_secret_key    = (sensitive value)
          - timestamp_format = "%Y-%m-%dT%H:%M:%S.000" -> null
        }


      # Warning: this block will be marked as sensitive and will not
      # display in UI output after applying this change.
      ~ snippet {
          # At least one attribute in this block is (or was) sensitive,
          # so its contents will not be displayed.
        }

        # (18 unchanged blocks hidden)
```

We should be guarded against these by the `activate = false` flag on the fastly services. I will confirm no inappropriate changes, activate, then remove that flag in a second PR.