### PR TITLE
Stop using AWS configuration profiles for terraform

### DIFF
--- a/terraform/config.tf
+++ b/terraform/config.tf
@@ -46,20 +46,17 @@ terraform {
 provider "aws" {
   alias   = "us-east-2"
   region  = "us-east-2"
-  profile = "psf-prod"
 }
 
 
 provider "aws" {
   alias   = "us-west-2"
   region  = "us-west-2"
-  profile = "psf-prod"
 }
 
 provider "aws" {
   alias   = "email"
   region  = "us-west-2"
-  profile = "psf-prod"
 }
 
 

--- a/terraform/email/main.tf
+++ b/terraform/email/main.tf
@@ -10,7 +10,6 @@ terraform {
 provider "aws" {
   alias   = "email"
   region  = "us-west-2"
-  profile = "psf-prod"
 }
 
 variable "name" { type = string }


### PR DESCRIPTION
This change moves away from fetching aws configs from named profiles, to just rely on the environment.

Because we only use one profile, its the simplest way to make this repository compaitble with terraform cloud for better collaboration tools