### PR TITLE
Monitoring: create a cache bypass for sentinel package in staging

### DIFF
--- a/terraform/file-hosting/vcl/staging.vcl
+++ b/terraform/file-hosting/vcl/staging.vcl
@@ -144,6 +144,10 @@ sub vcl_fetch {
         unset beresp.http.expires;
         set beresp.http.Cache-Control = "max-age=365000000, immutable, public";
         set beresp.ttl = 365000000s;
+        if (req.url == "/packages/aa/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/aaaaaaaaa-0.0.0.tar.gz") {
+            set beresp.http.Cache-Control = "max-age=0, immutable, public";
+            set beresp.ttl = 0s;
+        }
     }
 
     # If there is a Set-Cookie header, we'll ensure that we do not cache the


### PR DESCRIPTION
After an outage detailed at https://status.python.org/incidents/bt0tzq7x2fk2 it was recognized that our monitoring for files.pythonhosted.org was flawed. The file being requested was continuously held in cache due to the monitoring itself.

This creates a specifically named url that will never be cached, specifically for monitoring. We want to deploy this so that we can verify it works before pushing to prod.