### PR TITLE
remove Digicert.com from our CAA record

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -39,7 +39,6 @@ module "dns" {
   caa_issuers = [
     "amazon.com",
     "globalsign.com",
-    "Digicert.com",
   ]
 
   apex_txt = [


### PR DESCRIPTION
Our EV certification lapsed, and the pain of validation is honestly too high for any tangible benefit.

Since we don't intend to pursue EV certs with Digicert... and we're getting spammed with validation requests... drop it!