### PR TITLE
chore: disable waf

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -278,7 +278,7 @@ module "inspector" {
   ngwaf_site_name          = "pypi-inspector"
   ngwaf_email              = var.ngwaf_email
   ngwaf_token              = var.ngwaf_token
-  activate_ngwaf_service   = true
+  activate_ngwaf_service   = false
   edge_security_dictionary = "Edge_Security"
   fastly_key               = var.credentials["fastly"]
   ngwaf_percent_enabled    = 100


### PR DESCRIPTION
Now that we have the tf state properly managing the edge deployment (https://app.terraform.io/app/psf/workspaces/pypi-infra/runs/run-X7pZW6nwjHASQ4vd?organization_name=psf), I think we can properly flip ngwaf off (then on) to make it happy.

Currently it has the no agent bug which i think is due to manually running before doing the disable/enable mess that we had to do sometimes for pypi waf 