### PR TITLE
Handle CORS preflight for file hosting

### DIFF
--- a/terraform/file-hosting/vcl/files.vcl
+++ b/terraform/file-hosting/vcl/files.vcl
@@ -90,6 +90,14 @@ sub vcl_recv {
     # Requests that are for an *actual* file get disaptched to object storage instead of
     # to our typical backends.
 
+    # Handle CORS preflight for browser-based tooling.
+    # Range triggers preflight because it is not a CORS-safelisted header.
+    if (req.request == "OPTIONS" &&
+        req.http.Origin &&
+        req.http.Access-Control-Request-Method) {
+      error 204 "CORS preflight";
+    }
+
     # Do not bother to attempt to run the caching mechanisms for methods that
     # are not generally safe to cache.
     if (req.request != "HEAD" &&
@@ -516,8 +524,9 @@ sub vcl_deliver {
         # We want to set CORS headers allowing files to be loaded cross-origin
         unset resp.http.X-Permitted-Cross-Domain-Policies;
         set resp.http.Access-Control-Allow-Methods = "GET, OPTIONS";
-        set resp.http.Access-Control-Allow-Headers= "Range";
+        set resp.http.Access-Control-Allow-Headers = "Range";
         set resp.http.Access-Control-Allow-Origin = "*";
+        set resp.http.Access-Control-Expose-Headers = "Content-Length, Content-Range, Accept-Ranges";
     }
 
     # Rename or unset a few headers to send to clients.
@@ -569,6 +578,15 @@ sub vcl_error {
         set obj.response = "SNI is required";
         set obj.http.Content-Type = "text/plain; charset=UTF-8";
         synthetic {"SNI is required."};
+        return (deliver);
+    }
+
+    if (obj.status == 204 && obj.response == "CORS preflight") {
+        set obj.http.Access-Control-Allow-Origin = "*";
+        set obj.http.Access-Control-Allow-Methods = "GET, HEAD, OPTIONS";
+        set obj.http.Access-Control-Allow-Headers = "Range, Accept-Encoding";
+        set obj.http.Access-Control-Max-Age = "86400";
+        set obj.http.Content-Length = "0";
         return (deliver);
     }
 

--- a/terraform/file-hosting/vcl/files.vcl
+++ b/terraform/file-hosting/vcl/files.vcl
@@ -94,7 +94,8 @@ sub vcl_recv {
     # Range triggers preflight because it is not a CORS-safelisted header.
     if (req.request == "OPTIONS" &&
         req.http.Origin &&
-        req.http.Access-Control-Request-Method) {
+        req.http.Access-Control-Request-Method &&
+        req.url ~ "^/packages/[a-f0-9]{2}/[a-f0-9]{2}/[a-f0-9]{60}/") {
       error 204 "CORS preflight";
     }
 
@@ -587,6 +588,7 @@ sub vcl_error {
         set obj.http.Access-Control-Allow-Headers = "Range, Accept-Encoding";
         set obj.http.Access-Control-Max-Age = "86400";
         set obj.http.Content-Length = "0";
+        synthetic {""};
         return (deliver);
     }
 


### PR DESCRIPTION
Browser-based tools (pyscript, Pyodide, etc.) that use the Range header trigger CORS preflight OPTIONS requests, which currently fail because they hit the backend instead of being answered at the edge.

- Short-circuit OPTIONS preflight in vcl_recv with a synthetic 204
- Return proper CORS preflight headers in vcl_error
- Add Access-Control-Expose-Headers so JS can read Content-Length, Content-Range, and Accept-Ranges from range responses

Refs: https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS#simple_requests
Refs: https://fetch.spec.whatwg.org/#cors-safelisted-request-header