### PR TITLE
Don't set read-only Content-Length in `vcl_error` CORS preflight

### DIFF
--- a/terraform/file-hosting/vcl/files.vcl
+++ b/terraform/file-hosting/vcl/files.vcl
@@ -587,7 +587,6 @@ sub vcl_error {
         set obj.http.Access-Control-Allow-Methods = "GET, HEAD, OPTIONS";
         set obj.http.Access-Control-Allow-Headers = "Range, Accept-Encoding";
         set obj.http.Access-Control-Max-Age = "86400";
-        set obj.http.Content-Length = "0";
         synthetic {""};
         return (deliver);
     }


### PR DESCRIPTION
rm the line

```
Error: invalid configuration for Fastly Service (62OyyXk6MTgn4a4JO0NbIO): Variable `obj.http.Content-Length` cannot be modified at: (input Line 1090 Pos 13) set obj.http.Content-Length = "0"; ------------#######################-------
with module.file-hosting.fastly_service_vcl.files
on file-hosting/fastly-service.tf line 1, in resource "fastly_service_vcl" "files":

resource "fastly_service_vcl" "files" {
```